### PR TITLE
Fix memory and layout bugs, Add some feats.

### DIFF
--- a/Android/sdk/src/main/java/com/lynx/ui/image/LynxUIImage.java
+++ b/Android/sdk/src/main/java/com/lynx/ui/image/LynxUIImage.java
@@ -233,13 +233,19 @@ public class LynxUIImage
 
     private void setPadding() {
         int borderWidth = (int) mRenderObjectImpl.getStyle().mBorderWidth;
+        int paddingLeft = mRenderObjectImpl.getStyle().mPaddingLeft;
+        int paddingRight = mRenderObjectImpl.getStyle().mPaddingRight;
+        int paddingTop = mRenderObjectImpl.getStyle().mPaddingTop;
+        int paddingBottom = mRenderObjectImpl.getStyle().mPaddingBottom;
         if (isAnimatedImage
                 || (borderWidth > 0
                     && mRenderObjectImpl.getStyle().mBorderRadius == 0)) {
-            mView.setPadding(borderWidth, borderWidth, borderWidth, borderWidth);
-        } else {
-            mView.setPadding(0, 0, 0, 0);
+            paddingLeft +=borderWidth;
+            paddingTop += borderWidth;
+            paddingRight += borderWidth;
+            paddingBottom += borderWidth;
         }
+        mView.setPadding(paddingLeft, paddingTop, paddingRight, paddingBottom);
     }
 
     private void setScale(){

--- a/Android/sdk/src/main/java/com/lynx/ui/view/LynxUIView.java
+++ b/Android/sdk/src/main/java/com/lynx/ui/view/LynxUIView.java
@@ -58,6 +58,7 @@ public class LynxUIView extends LynxUIGroup<AndroidViewGroup> {
             }
         }
 
+        // Insert View
         if (nearestItem != null) {
             int index = mView.indexOfChild(nearestItem.getUI().getView());
             mView.addView(childView, index);

--- a/iOS/lynx/UI/Image/LynxUIImage.h
+++ b/iOS/lynx/UI/Image/LynxUIImage.h
@@ -4,6 +4,6 @@
 #import <UIKit/UIKit.h>
 #import "LynxUI.h"
 
-@interface LynxUIImage : LynxUI
+@interface LynxUIImage : LynxUI<UIImageView *>
 
 @end

--- a/iOS/lynx/UI/Image/LynxUIImage.mm
+++ b/iOS/lynx/UI/Image/LynxUIImage.mm
@@ -8,7 +8,7 @@
 
 @implementation LynxUIImage
 
-- (UIView *)createView:(LynxRenderObjectImpl *)impl {
+- (id)createView:(LynxRenderObjectImpl *)impl {
     return [[UIImageView alloc] init];
 }
 
@@ -26,18 +26,17 @@
         return;
     }
     // scale type
-    UIImageView* imageView = SAFE_CONVERT(self.view, UIImageView);
-    imageView.clipsToBounds = YES;
-    imageView.contentMode = UIViewContentModeScaleAspectFill;
+    self.view.clipsToBounds = YES;
+    self.view.contentMode = UIViewContentModeScaleAspectFill;
     switch(style.css_object_fit_) {
         case lynx::CSSIMAGE_OBJECT_FIT_FILL:
-            imageView.contentMode = UIViewContentModeScaleToFill;
+            self.view.contentMode = UIViewContentModeScaleToFill;
             break;
         case lynx::CSSIMAGE_OBJECT_FIT_CONTAIN:
-            imageView.contentMode = UIViewContentModeScaleAspectFit;
+            self.view.contentMode = UIViewContentModeScaleAspectFit;
             break;
         case lynx::CSSIMAGE_OBJECT_FIT_COVER:
-            imageView.contentMode = UIViewContentModeScaleAspectFill;
+            self.view.contentMode = UIViewContentModeScaleAspectFill;
             break;
         default:
             break;

--- a/iOS/lynx/UI/Label/LynxUILabel.h
+++ b/iOS/lynx/UI/Label/LynxUILabel.h
@@ -3,7 +3,8 @@
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 #import "LynxUI.h"
+#import "IOSLabel.h"
 
-@interface LynxUILabel : LynxUI
+@interface LynxUILabel : LynxUI<IOSLabel *>
 
 @end

--- a/iOS/lynx/UI/Label/LynxUILabel.mm
+++ b/iOS/lynx/UI/Label/LynxUILabel.mm
@@ -3,14 +3,13 @@
 #import <CoreGraphics/CGGeometry.h>
 #import "LynxStyleConvector.h"
 #import "LynxUILabel.h"
-#import "IOSLabel.h"
 #import "LynxRenderObjectImpl.h"
 
 #include "base/ios/common.h"
 
 @implementation LynxUILabel
 
-- (UIView *)createView:(LynxRenderObjectImpl *)impl {
+- (id)createView:(LynxRenderObjectImpl *)impl {
     UIView *view = [[IOSLabel alloc] init];
     view.clipsToBounds = YES;
     return view;
@@ -20,20 +19,19 @@
     if (!self.view) {
         return;
     }
-    UILabel* label = SAFE_CONVERT(self.view, UILabel);
     self.view.backgroundColor = [UIColor clearColor];
     self.view.alpha = style.opacity_;
-    label.textColor = COLOR_CONVERT(style.font_color_);
-    label.textAlignment = [CSSStyleConvector ConvectToTextAlignment:style.text_align_];
+    self.view.textColor = COLOR_CONVERT(style.font_color_);
+    self.view.textAlignment = [CSSStyleConvector ConvectToTextAlignment:style.text_align_];
     if (style.font_weight_ == lynx::CSSTEXT_FONT_WEIGHT_BOLD) {
-        label.font = [UIFont boldSystemFontOfSize:(style.font_size_)];
+        self.view.font = [UIFont boldSystemFontOfSize:(style.font_size_)];
     } else {
-        label.font = [UIFont systemFontOfSize:style.font_size_];
+        self.view.font = [UIFont systemFontOfSize:style.font_size_];
     }
 }
 
 - (void)setText:(NSString *)text {
-    ((UILabel *)self.view).text = text;
+    (self.view).text = text;
 }
 
 - (void)bindRenderObjectImpl:(LynxRenderObjectImpl *)impl {

--- a/iOS/lynx/UI/Label/LynxUILabel.mm
+++ b/iOS/lynx/UI/Label/LynxUILabel.mm
@@ -24,7 +24,7 @@
     self.view.textColor = COLOR_CONVERT(style.font_color_);
     self.view.textAlignment = [CSSStyleConvector ConvectToTextAlignment:style.text_align_];
     if (style.font_weight_ == lynx::CSSTEXT_FONT_WEIGHT_BOLD) {
-        self.view.font = [UIFont boldSystemFontOfSize:(style.font_size_)];
+        self.view.font = [UIFont boldSystemFontOfSize:style.font_size_];
     } else {
         self.view.font = [UIFont systemFontOfSize:style.font_size_];
     }

--- a/iOS/lynx/UI/ListView/LynxUIListView.h
+++ b/iOS/lynx/UI/ListView/LynxUIListView.h
@@ -5,7 +5,7 @@
 #import "LynxListViewController.h"
 #import "LynxUI.h"
 
-@interface LynxUIListView : LynxUI
+@interface LynxUIListView : LynxUI<UITableView *>
 
 @property(nonatomic, readonly) LynxListViewController *controller;
 

--- a/iOS/lynx/UI/ListView/LynxUIListView.mm
+++ b/iOS/lynx/UI/ListView/LynxUIListView.mm
@@ -5,7 +5,7 @@
 
 @implementation LynxUIListView 
 
-- (UIView *)createView:(LynxRenderObjectImpl *)impl {
+- (id)createView:(LynxRenderObjectImpl *)impl {
     UITableView *view = [[UITableView alloc] init];
     _controller = [[LynxListViewController alloc] init:(UITableView *)view withUI:self];
     view.dataSource = _controller;
@@ -16,13 +16,12 @@
 }
 
 - (void) setData:(id) value withKey:(LynxRenderObjectAttr) attr; {
-    UITableView *listView = SAFE_CONVERT(self.view, UITableView);
     switch (attr) {
         case SCROLL_LEFT:
-            [listView setContentOffset:CGPointMake([SAFE_CONVERT(value, NSNumber) intValue], 0) animated:YES];
+            [self.view setContentOffset:CGPointMake([SAFE_CONVERT(value, NSNumber) intValue], 0) animated:YES];
             break;
         case SCROLL_TOP:
-            [listView setContentOffset:CGPointMake(0, [SAFE_CONVERT(value, NSNumber) intValue]) animated:YES];
+            [self.view setContentOffset:CGPointMake(0, [SAFE_CONVERT(value, NSNumber) intValue]) animated:YES];
             break;
         default:
             break;

--- a/iOS/lynx/UI/ScrollView/LynxUIScrollView.h
+++ b/iOS/lynx/UI/ScrollView/LynxUIScrollView.h
@@ -3,7 +3,8 @@
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 #import "LynxUI.h"
+#import "IOSScrollView.h"
 
-@interface LynxUIScrollView : LynxUI
+@interface LynxUIScrollView : LynxUI<IOSScrollView *>
 
 @end

--- a/iOS/lynx/UI/ScrollView/LynxUIScrollView.mm
+++ b/iOS/lynx/UI/ScrollView/LynxUIScrollView.mm
@@ -1,7 +1,6 @@
 // Copyright 2017 The Lynx Authors. All rights reserved.
 
 #import "LynxUIScrollView.h"
-#import "IOSScrollView.h"
 #import "LynxRenderObjectImpl.h"
 
 #include "base/ios/common.h"
@@ -10,7 +9,7 @@
 
 static NSString * const kAttrPageEnable = @"page-enable";
 
-- (UIView *)createView:(LynxRenderObjectImpl *) impl {
+- (id)createView:(LynxRenderObjectImpl *) impl {
     return [[IOSScrollView alloc] initWithUI:self];
 }
 
@@ -23,7 +22,7 @@ static NSString * const kAttrPageEnable = @"page-enable";
 
 - (void) setSize:(const base::Size &)size {
     if(!self.view) return;
-    ((IOSScrollView *)self.view).contentSize = CGSizeMake(size.width_, size.height_);
+    self.view.contentSize = CGSizeMake(size.width_, size.height_);
 }
 
 - (void) insertChild:(LynxRenderObjectImpl *)child atIndex:(int)index {
@@ -38,13 +37,12 @@ static NSString * const kAttrPageEnable = @"page-enable";
 }
 
 - (void) setData:(id) value withKey:(LynxRenderObjectAttr) attr {
-    IOSScrollView *scrollView = SAFE_CONVERT(self.view, IOSScrollView);
     switch (attr) {
         case SCROLL_LEFT:
-            [scrollView setContentOffset:CGPointMake([SAFE_CONVERT(value, NSNumber) intValue], 0) animated:YES];
+            [self.view setContentOffset:CGPointMake([SAFE_CONVERT(value, NSNumber) intValue], 0) animated:YES];
             break;
         case SCROLL_TOP:
-            [scrollView setContentOffset:CGPointMake(0, [SAFE_CONVERT(value, NSNumber) intValue]) animated:YES];
+            [self.view setContentOffset:CGPointMake(0, [SAFE_CONVERT(value, NSNumber) intValue]) animated:YES];
             break;
         default:
             break;

--- a/iOS/lynx/UI/Slider/LynxUISlider.h
+++ b/iOS/lynx/UI/Slider/LynxUISlider.h
@@ -1,0 +1,8 @@
+// Copyright 2017 The Lynx Authors. All rights reserved.
+
+#import <Foundation/Foundation.h>
+#import "LynxUI.h"
+
+@interface LynxUISlider : LynxUI
+
+@end

--- a/iOS/lynx/UI/Slider/LynxUISlider.mm
+++ b/iOS/lynx/UI/Slider/LynxUISlider.mm
@@ -1,0 +1,70 @@
+// Copyright 2017 The Lynx Authors. All rights reserved.
+
+#import "LynxUISlider.h"
+#include "base/ios/common.h"
+
+static const NSString *kAttrMin = @"min";
+static const NSString *kAttrMax = @"max";
+static const NSString *kAttrValue = @"value";
+static const NSString *kAttrStep = @"step";
+static const NSString *kAttrActiveLineColor = @"active-line-color";
+static const NSString *kAttrBackgroundLineColor = @"background-line-color";
+static const NSString *kEventChange = @"change";
+
+static const NSInteger kDefaultMax = 100;
+static const NSInteger kDefaultMin = 0;
+
+@interface LynxUISlider()
+
+@property(nonatomic) NSInteger max;
+@property(nonatomic) NSInteger min;
+@property(nonatomic) NSInteger step;
+
+@end
+
+@implementation LynxUISlider
+
+- (UIView *)createView:(LynxRenderObjectImpl *)impl {
+    UISlider *view = [[UISlider alloc] init];
+    view.clipsToBounds = YES;
+    view.continuous = YES;
+    return view;
+}
+
+- (void)setAttribute:(NSString *)value forKey:(NSString *)key {
+    UISlider *sliderView = SAFE_CONVERT(self.view, UISlider);
+    if ([kAttrMax isEqualToString:key]) {
+        sliderView.maximumValue = value.floatValue;
+    } else if ([kAttrMin isEqualToString:key]) {
+        sliderView.minimumValue = value.floatValue;
+    } else if ([kAttrValue isEqualToString:key]) {
+        [sliderView setValue:value.floatValue animated:NO];
+    } else if ([kAttrStep isEqualToString:key]) {
+        _step = value.integerValue;
+    } else if ([kAttrActiveLineColor isEqualToString:key]) {
+        
+    } else if ([kAttrBackgroundLineColor isEqualToString:key]) {
+        
+    }
+}
+
+- (void)addEventListener:(NSString *)event {
+    UISlider *sliderView = SAFE_CONVERT(self.view, UISlider);
+    if ([kEventChange isEqualToString:event]) {
+        [sliderView addTarget:self action:@selector(valueChanged:) forControlEvents:UIControlEventValueChanged];
+    }
+}
+
+- (void)removeEventListener:(NSString *)event {
+    if ([kEventChange isEqualToString:event]) {
+        
+    }
+}
+
+- (void)valueChanged:(UISlider *)sender {
+    UISlider *sliderView = SAFE_CONVERT(self.view, UISlider);
+    NSInteger index = (NSInteger)(sliderView.value + 0.5);
+//    [sliderView setValue:index animated:NO];
+}
+
+@end

--- a/iOS/lynx/UI/Switch/LynxUISwitch.h
+++ b/iOS/lynx/UI/Switch/LynxUISwitch.h
@@ -1,0 +1,13 @@
+//
+//  LynxUISwitch.h
+//  lynx
+//
+//  Created by 燕行 on 17/10/25.
+//  Copyright © 2017年 lynx. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface LynxUISwitch : NSObject
+
+@end

--- a/iOS/lynx/UI/Switch/LynxUISwitch.m
+++ b/iOS/lynx/UI/Switch/LynxUISwitch.m
@@ -1,0 +1,13 @@
+//
+//  LynxUISwitch.m
+//  lynx
+//
+//  Created by 燕行 on 17/10/25.
+//  Copyright © 2017年 lynx. All rights reserved.
+//
+
+#import "LynxUISwitch.h"
+
+@implementation LynxUISwitch
+
+@end

--- a/iOS/lynx/UI/View/LynxUIView.h
+++ b/iOS/lynx/UI/View/LynxUIView.h
@@ -3,7 +3,8 @@
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 #import "LynxUI.h"
+#import "IOSView.h"
 
-@interface LynxUIView : LynxUI
+@interface LynxUIView : LynxUI<IOSView *>
 
 @end

--- a/iOS/lynx/UI/View/LynxUIView.mm
+++ b/iOS/lynx/UI/View/LynxUIView.mm
@@ -1,13 +1,12 @@
 // Copyright 2017 The Lynx Authors. All rights reserved.
 
 #import <CoreGraphics/CGGeometry.h>
-#import "IOSView.h"
 #import "LynxUIView.h"
 #import "LynxRenderObjectImpl.h"
 
 @implementation LynxUIView
 
-- (UIView *) createView:(LynxRenderObjectImpl *) impl {
+- (id) createView:(LynxRenderObjectImpl *) impl {
     return [[IOSView alloc]initWithUI:self];;
 }
 
@@ -23,11 +22,11 @@
 }
 
 - (void) addEventListener:(NSString *)event {
-    [(IOSView*)self.view addEvent:event];
+    [self.view addEvent:event];
 }
 
 - (void) removeEventListener:(NSString *)event {
-    [(IOSView*)self.view removeEvent:event];
+    [self.view removeEvent:event];
 }
 
 @end

--- a/lynx/base/android/jni_helper.h
+++ b/lynx/base/android/jni_helper.h
@@ -31,7 +31,7 @@ namespace base {
             static std::string ConvertToString(JNIEnv* env, jstring value);
 
             static base::android::ScopedLocalJavaRef<jobject> ConvertToJNIObject
-                    (JNIEnv *env, jscore::LynxValue *);
+                    (JNIEnv *env, jscore::LynxValue*);
             static base::android::ScopedLocalJavaRef<jobjectArray> ConvertToJNIObjectArray
                     (JNIEnv* env, jscore::LynxArray*);
             static base::android::ScopedLocalJavaRef<jobject> ConvertToJNIArray
@@ -64,39 +64,41 @@ namespace base {
                 return (bool)(value == JNI_TRUE);
             }
 
-            static jscore::LynxObject* ConvertToLynxObject(JNIEnv *env,
+            static base::ScopedPtr<jscore::LynxObject> ConvertToLynxObject(JNIEnv *env,
                                                            jobject value);
-            static jscore::LynxFunctionObject* ConvertToLynxFunctionObject(JNIEnv *env,
-                                                                           jobject value);
-            static jscore::LynxArray* ConvertToLynxArray(JNIEnv *env,
+            static base::ScopedPtr<jscore::LynxFunctionObject> ConvertToLynxFunctionObject(
+                    JNIEnv *env,
+                    jobject value);
+            static base::ScopedPtr<jscore::LynxArray> ConvertToLynxArray(JNIEnv *env,
                                                          jobject value);
-            static jscore::LynxArray* ConvertToLynxArray(JNIEnv *env,
+            static base::ScopedPtr<jscore::LynxArray> ConvertToLynxArray(JNIEnv *env,
                                                          jobject value,
                                                          char type);
-            static jscore::LynxArray* ConvertToLynxArray(JNIEnv *env,
+            static base::ScopedPtr<jscore::LynxArray> ConvertToLynxArray(JNIEnv *env,
                                                          jintArray java_array);
-            static jscore::LynxArray* ConvertToLynxArray(JNIEnv *env,
+            static base::ScopedPtr<jscore::LynxArray> ConvertToLynxArray(JNIEnv *env,
                                                          jshortArray java_array);
-            static jscore::LynxArray* ConvertToLynxArray(JNIEnv *env,
+            static base::ScopedPtr<jscore::LynxArray> ConvertToLynxArray(JNIEnv *env,
                                                          jlongArray java_array);
-            static jscore::LynxArray* ConvertToLynxArray(JNIEnv *env,
+            static base::ScopedPtr<jscore::LynxArray> ConvertToLynxArray(JNIEnv *env,
                                                          jfloatArray java_array);
-            static jscore::LynxArray* ConvertToLynxArray(JNIEnv *env,
+            static base::ScopedPtr<jscore::LynxArray> ConvertToLynxArray(JNIEnv *env,
                                                          jdoubleArray java_array);
-            static jscore::LynxArray* ConvertToLynxArray(JNIEnv *env,
+            static base::ScopedPtr<jscore::LynxArray> ConvertToLynxArray(JNIEnv *env,
                                                          jbooleanArray java_array);
-            static jscore::LynxArray* ConvertToLynxArray(JNIEnv *env,
+            static base::ScopedPtr<jscore::LynxArray> ConvertToLynxArray(JNIEnv *env,
                                                          jbyteArray java_array);
-            static jscore::LynxArray* ConvertToLynxArray(JNIEnv *env,
+            static base::ScopedPtr<jscore::LynxArray> ConvertToLynxArray(JNIEnv *env,
                                                          const jobjectArray args);
-            static jscore::LynxValue* ConvertToLynxValue(JNIEnv *env,
+            static base::ScopedPtr<jscore::LynxValue> ConvertToLynxValue(JNIEnv *env,
                                                          jobject value,
                                                          const std::string &type);
-            static jscore::LynxValue* ConvertToLynxValue(JNIEnv *env, jobject java_obj);
+            static base::ScopedPtr<jscore::LynxValue> ConvertToLynxValue(JNIEnv *env,
+                                                                         jobject java_obj);
 
 
         private:
-            static jscore::LynxValue* ConvertToLynxValue(JNIEnv *env,
+            static base::ScopedPtr<jscore::LynxValue> ConvertToLynxValue(JNIEnv *env,
                                                          jobject value,
                                                          char first,
                                                          char second);

--- a/lynx/base/debug/timing_tracker.cpp
+++ b/lynx/base/debug/timing_tracker.cpp
@@ -4,18 +4,15 @@
 #include "base/debug/timing_tracker.h"
 
 namespace base {
-    TimeingTracker::TimeingTracker(const char* log) {
+    TimingTracker::TimingTracker(const char* log) {
         log_ = log;
-        gettimeofday(&time_, nullptr);
+        start_ = std::chrono::high_resolution_clock::now();
     }
 
-    TimeingTracker::~TimeingTracker() {
-        timeval end;
-        gettimeofday(&end, nullptr);
-
-        long micros_start = (time_.tv_sec * 1000 * 1000) + (time_.tv_usec);
-        long micros_end = (end.tv_sec * 1000 * 1000) + (end.tv_usec);
-        long interval = micros_end - micros_start;
-        LOGD("lynx-timing", "%s end(%lfms)",log_, interval/1000.0);
+    TimingTracker::~TimingTracker() {
+        auto finish = std::chrono::high_resolution_clock::now();
+        double cost = std::chrono::duration_cast<std::chrono::nanoseconds>(finish-start_).count()
+                      / 1000000.0;
+        LOGD("lynx-timing", "%s end(%lfms)", log_, cost);
     }
 }

--- a/lynx/base/debug/timing_tracker.h
+++ b/lynx/base/debug/timing_tracker.h
@@ -4,15 +4,16 @@
 #define BASE_DEBUG_TIMING_PERFORMANCE_H_
 
 
-#include<sys/time.h>
+#include <chrono>
+
 namespace base {
-    class TimeingTracker {
+    class TimingTracker {
     public:
-        TimeingTracker(const char *log);
-        ~TimeingTracker();
+        TimingTracker(const char *log);
+        ~TimingTracker();
 
     private:
-        timeval time_;
+        std::chrono::time_point<std::chrono::system_clock, std::chrono::nanoseconds> start_;
         const char *log_;
     };
 }

--- a/lynx/base/ios/oc_helper.cpp
+++ b/lynx/base/ios/oc_helper.cpp
@@ -68,8 +68,8 @@ namespace base {
             return array;
         }
         
-        jscore::LynxValue* OCHelper::ConvertToLynxValue(id value) {
-            jscore::LynxValue* lynx_value = 0;
+        base::ScopedPtr<jscore::LynxValue> OCHelper::ConvertToLynxValue(id value) {
+            base::ScopedPtr<jscore::LynxValue> lynx_value;
             if ([value isKindOfClass:[NSNumber class]]) {
                 NSNumber *number = SAFE_CONVERT(value, NSNumber);
                 char type = number.objCType[0];
@@ -97,26 +97,26 @@ namespace base {
             }
             return lynx_value;
         }
-        
-        jscore::LynxObject* OCHelper::ConvertToLynxObject(NSDictionary *dic) {
-            if (!dic) return NULL;
-            jscore::LynxObject* lynx_object = lynx_new jscore::LynxObject();
+
+        base::ScopedPtr<jscore::LynxObject> OCHelper::ConvertToLynxObject(NSDictionary *dic) {
+            if (!dic) return base::ScopedPtr<jscore::LynxObject>();
+            base::ScopedPtr<jscore::LynxObject> lynx_object(lynx_new jscore::LynxObject());
             NSArray *key_array = [dic allKeys];
             for (NSUInteger i = 0; i < key_array.count; ++i) {
                 NSString *key = SAFE_CONVERT([key_array objectAtIndex:i], NSString);
                 id item = [dic objectForKey:key];
-                lynx_object->Set([key UTF8String], ConvertToLynxValue(item));
+                lynx_object->Set([key UTF8String], ConvertToLynxValue(item).Release());
             }
             return lynx_object;
         }
         
-        jscore::LynxArray* OCHelper::ConvertToLynxArray(NSArray *array) {
-            if (!array) return NULL;
+        base::ScopedPtr<jscore::LynxArray> OCHelper::ConvertToLynxArray(NSArray *array) {
+            if (!array) return base::ScopedPtr<jscore::LynxArray>();
             NSUInteger length = array.count;
-            jscore::LynxArray* lynx_array = lynx_new jscore::LynxArray();
+            base::ScopedPtr<jscore::LynxArray> lynx_array(lynx_new jscore::LynxArray());
             for (NSUInteger i = 0; i < length; ++i) {
                 id value = [array objectAtIndex:i];
-                jscore::LynxValue* lynx_value = ConvertToLynxValue(value);
+                jscore::LynxValue* lynx_value = ConvertToLynxValue(value).Release();
                 lynx_array->Push(lynx_value);
             }
             return lynx_array;

--- a/lynx/base/ios/oc_helper.h
+++ b/lynx/base/ios/oc_helper.h
@@ -20,9 +20,9 @@ namespace base {
             static NSArray* ConvertToOCArray(jscore::LynxArray* array);
             static NSDictionary* ConvertToOCObject(jscore::LynxObject* object);
             
-            static jscore::LynxArray* ConvertToLynxArray(NSArray *array);
-            static jscore::LynxObject* ConvertToLynxObject(NSDictionary *dic);
-            static jscore::LynxValue* ConvertToLynxValue(id value);
+            static base::ScopedPtr<jscore::LynxArray> ConvertToLynxArray(NSArray *array);
+            static base::ScopedPtr<jscore::LynxObject> ConvertToLynxObject(NSDictionary *dic);
+            static base::ScopedPtr<jscore::LynxValue> ConvertToLynxValue(id value);
         };
     }
 }

--- a/lynx/base/position.h
+++ b/lynx/base/position.h
@@ -69,6 +69,13 @@ class Position {
         return true;
     }
 
+    bool NeedToReset(int left, int top, int right, int bottom) {
+        return !(left_ == left &&
+            top_ == top &&
+            right_ == right &&
+            bottom_ == bottom);
+    }
+
     inline int GetWidth() const {
         int width = right_ - left_;
         return width > 0 ? width : 0;

--- a/lynx/layout/css_layout.cpp
+++ b/lynx/layout/css_layout.cpp
@@ -56,16 +56,16 @@ namespace lynx {
     }
 
     bool CSSStaticLayout::measureSpecially(LayoutObject* renderer, int width, int height) {
-        CSSStyle* childStyle = renderer->GetStyle();
-        if(childStyle->visible_ == CSS_HIDDEN
-                || childStyle->css_display_type_ == CSS_DISPLAY_NONE) {
+        CSSStyle* style = renderer->GetStyle();
+        if(style->visible_ == CSS_HIDDEN
+                || style->css_display_type_ == CSS_DISPLAY_NONE) {
             return true;
         }
-        if(childStyle->css_position_type_ == CSS_POSITION_ABSOLUTE) {
+        if(style->css_position_type_ == CSS_POSITION_ABSOLUTE) {
             measureAbsolute(renderer, width, height);
             return true;
         }
-        if(childStyle->css_position_type_ == CSS_POSITION_FIXED) {
+        if(style->css_position_type_ == CSS_POSITION_FIXED) {
             measureFixed(renderer);
             return true;
         }
@@ -87,33 +87,33 @@ namespace lynx {
             int measureWidth;
 
             LayoutObject* child = (LayoutObject*)renderer->Find(i);
-            CSSStyle* childStyle = child->GetStyle();
+            CSSStyle* style = child->GetStyle();
 
             if(measureSpecially(child, width, height)) {
                 continue;
             }
 
-            if(childStyle->flex_ > 0) {
-                totalFlex += childStyle->flex_;
-                calcWidth += childStyle->margin_left_ + childStyle->margin_right_;
+            if(style->flex_ > 0) {
+                totalFlex += style->flex_;
+                calcWidth += style->margin_left_ + style->margin_right_;
                 continue;
             }
 
-            if(!CSS_IS_UNDEFINED(childStyle->width_)){
-                measureWidth = Size::Descriptor::Make(childStyle->ClampWidth(), Size::Descriptor::EXACTLY);
+            if(!CSS_IS_UNDEFINED(style->width_)){
+                measureWidth = Size::Descriptor::Make(style->ClampWidth(), Size::Descriptor::EXACTLY);
             }else{
-                measureWidth = Size::Descriptor::Make(residualWidth - childStyle->margin_left_ - childStyle->margin_right_, Size::Descriptor::AT_MOST);
+                measureWidth = Size::Descriptor::Make(residualWidth - style->margin_left_ - style->margin_right_, Size::Descriptor::AT_MOST);
             }
 
             Size childSize = child->Measure(measureWidth, Size::Descriptor::Make(height, Size::Descriptor::AT_MOST));
 
-            calcWidth += childSize.width_ + childStyle->margin_left_ + childStyle->margin_right_;
+            calcWidth += childSize.width_ + style->margin_left_ + style->margin_right_;
             calcHeight = childSize.height_;
 
             //residualWidth = width - calcWidth;
 
 
-            int childIteheight_ = calcHeight + childStyle->margin_bottom_ + childStyle->margin_top_;
+            int childIteheight_ = calcHeight + style->margin_bottom_ + style->margin_top_;
             measuredSize.height_ = measuredSize.height_ > childIteheight_ ? measuredSize.height_ : childIteheight_;
         }
 
@@ -125,21 +125,21 @@ namespace lynx {
         for(int i = start; i <= end; i++) {
 
             LayoutObject* child = (LayoutObject*)renderer->Find(i);
-            CSSStyle* childStyle = child->GetStyle();
+            CSSStyle* style = child->GetStyle();
 
-            if(childStyle->visible_ == CSS_HIDDEN
-                    || childStyle->css_display_type_ == CSS_DISPLAY_NONE) {
+            if(style->visible_ == CSS_HIDDEN
+                    || style->css_display_type_ == CSS_DISPLAY_NONE) {
                 continue;
             }
-            if(childStyle->css_position_type_ == CSS_POSITION_ABSOLUTE
-                    || childStyle->css_position_type_ == CSS_POSITION_FIXED) {
+            if(style->css_position_type_ == CSS_POSITION_ABSOLUTE
+                    || style->css_position_type_ == CSS_POSITION_FIXED) {
                 continue;
             }
 
-            if(childStyle->flex_ <= 0) continue;
+            if(style->flex_ <= 0) continue;
 
             //根据flex属性重新计算子view宽度
-            int recalcWidth = residualWidth * childStyle->flex_/totalFlex;
+            int recalcWidth = residualWidth * style->flex_/totalFlex;
 
             int measureWidth = recalcWidth == 0 ? Size::Descriptor::Make(width, Size::Descriptor::AT_MOST) : Size::Descriptor::Make(recalcWidth, Size::Descriptor::EXACTLY);
             //测量子view的宽高/
@@ -151,7 +151,7 @@ namespace lynx {
             calcHeight = childSize.height_;
 
 
-            int childIteheight_ = calcHeight + childStyle->margin_bottom_ + childStyle->margin_top_;
+            int childIteheight_ = calcHeight + style->margin_bottom_ + style->margin_top_;
             measuredSize.height_ = measuredSize.height_ > childIteheight_ ? measuredSize.height_ : childIteheight_;
 
         }
@@ -172,22 +172,22 @@ namespace lynx {
         for(int index = 0, childViewCount = renderer->GetChildCount(); index < childViewCount;) {
 
             LayoutObject* child = (LayoutObject*)renderer->Find(index);
-            CSSStyle* childStyle = child->GetStyle();
+            CSSStyle* style = child->GetStyle();
 
             if(measureSpecially(child, width, height)) {
                 continue;
             }
 
-            int measureWidth = width - childStyle->margin_left_ - childStyle->margin_right_;
+            int measureWidth = width - style->margin_left_ - style->margin_right_;
             Size childSize = Size(0, 0);
 
-            if(childStyle->flex_ == 0) {
+            if(style->flex_ == 0) {
 
                 childSize = child->Measure(Size::Descriptor::Make(measureWidth, Size::Descriptor::AT_MOST),
                         Size::Descriptor::Make(height, Size::Descriptor::AT_MOST));
             }
 
-            currentCalcWidth = currentCalcWidth + childSize.width_ + childStyle->margin_left_ + childStyle->margin_right_;
+            currentCalcWidth = currentCalcWidth + childSize.width_ + style->margin_left_ + style->margin_right_;
             if(currentCalcWidth <= width) {
                 calcWidth = currentCalcWidth;
                 if(index == childViewCount - 1) {
@@ -248,30 +248,30 @@ namespace lynx {
             int measureHeight;
 
             LayoutObject* child = (LayoutObject*)renderer->Find(i);
-            CSSStyle* childStyle = child->GetStyle();
+            CSSStyle* style = child->GetStyle();
 
             if(measureSpecially(child, width, height)) {
                 continue;
             }
 
-            if(childStyle->flex_ > 0) {
-                totalFlex += childStyle->flex_;
-                calcHeight += childStyle->margin_top_ + childStyle->margin_bottom_;
+            if(style->flex_ > 0) {
+                totalFlex += style->flex_;
+                calcHeight += style->margin_top_ + style->margin_bottom_;
                 continue;
             }
 
-            if(!CSS_IS_UNDEFINED(childStyle->height_)){
-                measureHeight = Size::Descriptor::Make(childStyle->ClampHeight(), Size::Descriptor::EXACTLY);
+            if(!CSS_IS_UNDEFINED(style->height_)){
+                measureHeight = Size::Descriptor::Make(style->ClampHeight(), Size::Descriptor::EXACTLY);
             }else{
-                measureHeight = Size::Descriptor::Make(residualHeight - childStyle->margin_top_ - childStyle->margin_bottom_, Size::Descriptor::AT_MOST);
+                measureHeight = Size::Descriptor::Make(residualHeight - style->margin_top_ - style->margin_bottom_, Size::Descriptor::AT_MOST);
             }
 
             Size childSize = child->Measure(Size::Descriptor::Make(width, Size::Descriptor::AT_MOST), measureHeight);
 
             calcWidth = childSize.width_;
-            calcHeight += childSize.height_ + childStyle->margin_top_ + childStyle->margin_bottom_;
+            calcHeight += childSize.height_ + style->margin_top_ + style->margin_bottom_;
 
-            int childItewidth_ = calcWidth + childStyle->margin_left_ + childStyle->margin_right_;
+            int childItewidth_ = calcWidth + style->margin_left_ + style->margin_right_;
             measuredSize.width_ = measuredSize.width_ > childItewidth_ ? measuredSize.width_ : childItewidth_;
         }
 
@@ -283,21 +283,21 @@ namespace lynx {
         for(int i = start; i <= end; i++) {
 
             LayoutObject* child = (LayoutObject*)renderer->Find(i);
-            CSSStyle* childStyle = child->GetStyle();
+            CSSStyle* style = child->GetStyle();
 
-            if(childStyle->visible_ == CSS_HIDDEN
-                    || childStyle->css_display_type_ == CSS_DISPLAY_NONE) {
+            if(style->visible_ == CSS_HIDDEN
+                    || style->css_display_type_ == CSS_DISPLAY_NONE) {
                 continue;
             }
-            if(childStyle->css_position_type_ == CSS_POSITION_ABSOLUTE
-                    || childStyle->css_position_type_ == CSS_POSITION_FIXED) {
+            if(style->css_position_type_ == CSS_POSITION_ABSOLUTE
+                    || style->css_position_type_ == CSS_POSITION_FIXED) {
                 continue;
             }
 
-            if(childStyle->flex_ <= 0) continue;
+            if(style->flex_ <= 0) continue;
 
             //根据flex属性重新计算子view宽度
-            int recalcHeight = residualHeight * childStyle->flex_/totalFlex;
+            int recalcHeight = residualHeight * style->flex_/totalFlex;
 
             //测量子view的宽高/
             int measureHeight = recalcHeight == 0 ? Size::Descriptor::Make(height, Size::Descriptor::AT_MOST) : Size::Descriptor::Make(recalcHeight, Size::Descriptor::EXACTLY);
@@ -309,7 +309,7 @@ namespace lynx {
             calcHeight += childSize.height_;
 
 
-            int childItewidth_ = calcWidth + childStyle->margin_left_ + childStyle->margin_right_;
+            int childItewidth_ = calcWidth + style->margin_left_ + style->margin_right_;
             measuredSize.width_ = measuredSize.width_ > childItewidth_ ? measuredSize.width_ : childItewidth_;
 
         }
@@ -329,22 +329,22 @@ namespace lynx {
         for(int index = 0, childViewCount = renderer->GetChildCount(); index < childViewCount;) {
 
             LayoutObject* child = (LayoutObject*)renderer->Find(index);
-            CSSStyle* childStyle = child->GetStyle();
+            CSSStyle* style = child->GetStyle();
 
             if(measureSpecially(child, width, height)) {
                 continue;
             }
 
-            int measureHeight = height - childStyle->margin_top_ - childStyle->margin_bottom_;
+            int measureHeight = height - style->margin_top_ - style->margin_bottom_;
             Size childSize = Size(0, 0);
 
-            if(childStyle->flex_ == 0) {
+            if(style->flex_ == 0) {
 
                 childSize = child->Measure(Size::Descriptor::Make(width, Size::Descriptor::AT_MOST),
                         Size::Descriptor::Make(measureHeight, Size::Descriptor::AT_MOST));
             }
 
-            currentCalcHeight = currentCalcHeight + childSize.height_ + childStyle->margin_top_ + childStyle->margin_bottom_;
+            currentCalcHeight = currentCalcHeight + childSize.height_ + style->margin_top_ + style->margin_bottom_;
             if(currentCalcHeight <= height) {
                 calcHeight = currentCalcHeight;
                 if(index == childViewCount - 1) {
@@ -429,20 +429,20 @@ namespace lynx {
         for (int index = 0, childViewCount = renderer->GetChildCount(); index < childViewCount; index++) {
 
             LayoutObject* child = (LayoutObject*)renderer->Find(index);
-            CSSStyle* childStyle = child->GetStyle();
+            CSSStyle* style = child->GetStyle();
 
             bool shouldChildPass = false;
             int oldTotalUseWidthWithoutAbsolute = totalUseWidthWithoutAbsolute;
-            if(childStyle->visible_ == CSS_HIDDEN ||
-                    childStyle->css_display_type_ == CSS_DISPLAY_NONE) {
+            if(style->visible_ == CSS_HIDDEN ||
+                    style->css_display_type_ == CSS_DISPLAY_NONE) {
                 child->Layout(0, 0, 0, 0);
                 shouldChildPass = true;
             }
-            if(childStyle->css_position_type_ == CSS_POSITION_ABSOLUTE) {
+            if(style->css_position_type_ == CSS_POSITION_ABSOLUTE) {
                 layoutAbsolute(renderer, child, width, height);
                 shouldChildPass = true;
             }
-            if(childStyle->css_position_type_ == CSS_POSITION_FIXED) {
+            if(style->css_position_type_ == CSS_POSITION_FIXED) {
                 layoutFixed(renderer, child);
                 shouldChildPass = true;
             }
@@ -451,12 +451,12 @@ namespace lynx {
 
                 currentRowWithoutAbsoluteCount++;
 
-                totalUseWidthWithoutAbsolute += child->GetMeasuredSize().width_ + childStyle->margin_left_ + childStyle->margin_right_;
+                totalUseWidthWithoutAbsolute += child->GetMeasuredSize().width_ + style->margin_left_ + style->margin_right_;
 
             }
 
             if(totalUseWidthWithoutAbsolute <= availableWidth) {
-                int childHeight = child->GetMeasuredSize().height_ + childStyle->margin_top_ + childStyle->margin_bottom_;
+                int childHeight = child->GetMeasuredSize().height_ + style->margin_top_ + style->margin_bottom_;
                 currentLineHeight = currentLineHeight > childHeight ? currentLineHeight : childHeight;
             }
 
@@ -507,40 +507,40 @@ namespace lynx {
                 for (int i = start; i <= index; i++) {
 
                     LayoutObject* recalcChild = (LayoutObject*)renderer->Find(i);
-                    CSSStyle* recalcChildStyle = recalcChild->GetStyle();
+                    CSSStyle* recalcstyle = recalcChild->GetStyle();
 
                     CSSStyleType align = itemStyle->flex_align_items_;
 
-                    if(recalcChildStyle->visible_ == CSS_HIDDEN ||
-                            recalcChildStyle->css_display_type_ == CSS_DISPLAY_NONE) {
+                    if(recalcstyle->visible_ == CSS_HIDDEN ||
+                            recalcstyle->css_display_type_ == CSS_DISPLAY_NONE) {
                         recalcChild->Layout(0,0,0,0);
                         continue;
                     }
-                    if(recalcChildStyle->css_position_type_ == CSS_POSITION_ABSOLUTE ||
-                            recalcChildStyle->css_position_type_ == CSS_POSITION_FIXED) {
+                    if(recalcstyle->css_position_type_ == CSS_POSITION_ABSOLUTE ||
+                            recalcstyle->css_position_type_ == CSS_POSITION_FIXED) {
                         continue;
                     }
 
-                    if(recalcChildStyle->flex_align_self_ != CSSFLEX_ALIGN_AUTO) {
-                        align = recalcChildStyle->flex_align_self_;
+                    if(recalcstyle->flex_align_self_ != CSSFLEX_ALIGN_AUTO) {
+                        align = recalcstyle->flex_align_self_;
                     }
 
 
                     int oldChildOriginY = childOriginY;
 
-                    childOriginX += recalcChildStyle->margin_left_;
+                    childOriginX += recalcstyle->margin_left_;
                     if(i > start)
                         childOriginX += adjustWidthInterval;
-                    childOriginY += recalcChildStyle->margin_top_;
+                    childOriginY += recalcstyle->margin_top_;
 
                     int adjustY = 0;
                     int adjustHeight = CSS_UNDEFINED;
                     if(align == CSSFLEX_ALIGN_FLEX_START) {
                         //do nothing
                     }else if(align == CSSFLEX_ALIGN_FLEX_END) {
-                        adjustY = currentLineHeight - recalcChildStyle->margin_bottom_ - recalcChild->GetMeasuredSize().height_;
+                        adjustY = currentLineHeight - recalcstyle->margin_bottom_ - recalcChild->GetMeasuredSize().height_;
                     }else if(align == CSSFLEX_ALIGN_STRETCH) {
-                        adjustHeight = currentLineHeight - recalcChildStyle->margin_top_ - recalcChildStyle->margin_bottom_;
+                        adjustHeight = currentLineHeight - recalcstyle->margin_top_ - recalcstyle->margin_bottom_;
                         adjustHeight = recalcChild->GetStyle()->ClampHeight(adjustHeight);
                     }else if(align == CSSFLEX_ALIGN_CENTER) {
                         adjustY = (currentLineHeight - recalcChild->GetMeasuredSize().height_)/2;
@@ -554,9 +554,9 @@ namespace lynx {
 
                     recalcChild->Layout(l,t,r,b);
 
-                    childOriginX += recalcChild->GetMeasuredSize().width_ + recalcChildStyle->margin_right_;
+                    childOriginX += recalcChild->GetMeasuredSize().width_ + recalcstyle->margin_right_;
                     childOriginY = oldChildOriginY;
-                    int childIteheight_ = (b-t) + recalcChildStyle->margin_bottom_ + recalcChildStyle->margin_top_;
+                    int childIteheight_ = (b-t) + recalcstyle->margin_bottom_ + recalcstyle->margin_top_;
                     maxHeight = maxHeight < childIteheight_ ? childIteheight_ : maxHeight;
                 }
                 start = index + 1;
@@ -583,18 +583,18 @@ namespace lynx {
             for (int index = 0, childViewCount = renderer->GetChildCount(); index < childViewCount; index++) {
 
                 LayoutObject* child = (LayoutObject*)renderer->Find(index);
-                CSSStyle* childStyle = child->GetStyle();
+                CSSStyle* style = child->GetStyle();
 
-                if(childStyle->visible_ == CSS_HIDDEN ||
-                        childStyle->css_display_type_ == CSS_DISPLAY_NONE) {
+                if(style->visible_ == CSS_HIDDEN ||
+                        style->css_display_type_ == CSS_DISPLAY_NONE) {
                     child->Layout(0,0,0,0);
                     continue;
                 }
-                if(childStyle->css_position_type_ == CSS_POSITION_ABSOLUTE) {
+                if(style->css_position_type_ == CSS_POSITION_ABSOLUTE) {
                     layoutAbsolute(renderer, child, width, height);
                     continue;
                 }
-                if(childStyle->css_position_type_ == CSS_POSITION_FIXED) {
+                if(style->css_position_type_ == CSS_POSITION_FIXED) {
                     layoutFixed(renderer, child);
                     continue;
                 }
@@ -631,41 +631,41 @@ namespace lynx {
             int childOriginY = itemStyle->padding_top_ + itemStyle->border_width_;
             for (int i = 0, size = renderer->GetChildCount(); i < size; i++) {
                 LayoutObject* child = (LayoutObject*)renderer->Find(i);
-                CSSStyle* childStyle = child->GetStyle();
+                CSSStyle* style = child->GetStyle();
 
                 CSSStyleType align = itemStyle->flex_align_items_;
 
-                if(childStyle->visible_ == CSS_HIDDEN) {
+                if(style->visible_ == CSS_HIDDEN) {
                     child->Layout(0,0,0,0);
                     continue;
                 }
-                if(childStyle->css_position_type_ == CSS_POSITION_ABSOLUTE ||
-                        childStyle->css_position_type_ == CSS_POSITION_FIXED ||
-                        childStyle->css_display_type_ == CSS_DISPLAY_NONE) {
+                if(style->css_position_type_ == CSS_POSITION_ABSOLUTE ||
+                        style->css_position_type_ == CSS_POSITION_FIXED ||
+                        style->css_display_type_ == CSS_DISPLAY_NONE) {
                     firstShowIndex++;
                     continue;
                 }
 
-                if(childStyle->flex_align_self_ != CSSFLEX_ALIGN_AUTO) {
-                    align = childStyle->flex_align_self_;
+                if(style->flex_align_self_ != CSSFLEX_ALIGN_AUTO) {
+                    align = style->flex_align_self_;
                 }
 
                 int oldChildOriginY = childOriginY;
 
-                childOriginX += childStyle->margin_left_;
+                childOriginX += style->margin_left_;
                 if(i > firstShowIndex)
                     childOriginX += adjustWidthInterval;
-                childOriginY += childStyle->margin_top_;
+                childOriginY += style->margin_top_;
 
                 int adjustY = 0;
                 int adjustHeight = CSS_UNDEFINED;
                 if(align == CSSFLEX_ALIGN_FLEX_START) {
                     //do nothing
                 }else if(align == CSSFLEX_ALIGN_FLEX_END) {
-                    adjustY = availableHeight - childStyle->margin_bottom_ - child->GetMeasuredSize().height_;
+                    adjustY = availableHeight - style->margin_bottom_ - child->GetMeasuredSize().height_;
                 }else if(align == CSSFLEX_ALIGN_STRETCH) {
-                    if (CSS_IS_UNDEFINED(childStyle->height_)) {
-                        adjustHeight = availableHeight - childStyle->margin_top_ - childStyle->margin_bottom_;
+                    if (CSS_IS_UNDEFINED(style->height_)) {
+                        adjustHeight = availableHeight - style->margin_top_ - style->margin_bottom_;
                         adjustHeight = child->GetStyle()->ClampHeight(adjustHeight);
                     }
                 }else if(align == CSSFLEX_ALIGN_CENTER) {
@@ -680,7 +680,7 @@ namespace lynx {
                         : childOriginY + adjustHeight;
                 child->Layout(l,t,r,b);
 
-                childOriginX += child->GetMeasuredSize().width_ + childStyle->margin_right_;
+                childOriginX += child->GetMeasuredSize().width_ + style->margin_right_;
                 childOriginY = oldChildOriginY;
             }
         }else {
@@ -710,39 +710,39 @@ namespace lynx {
 
         for (int index = 0; index < size; index++) {
             LayoutObject* child = (LayoutObject*)renderer->Find(index);
-            CSSStyle* childStyle = child->GetStyle();
+            CSSStyle* style = child->GetStyle();
 
             bool childShouldPass = false;
             int oldTotalUseHeightWithoutAbsolute = totalUseHeightWithoutAbsolute;
-            if(childStyle->visible_ == CSS_HIDDEN ||
-                    childStyle->css_display_type_ == CSS_DISPLAY_NONE) {
+            if(style->visible_ == CSS_HIDDEN ||
+                    style->css_display_type_ == CSS_DISPLAY_NONE) {
                 child->Layout(0, 0, 0, 0);
                 childShouldPass = true;
             }
-            if(childStyle->css_position_type_ == CSS_POSITION_ABSOLUTE) {
+            if(style->css_position_type_ == CSS_POSITION_ABSOLUTE) {
                 layoutAbsolute(renderer, child, width, height);
                 childShouldPass = true;
             }
-            if(childStyle->css_position_type_ == CSS_POSITION_FIXED) {
+            if(style->css_position_type_ == CSS_POSITION_FIXED) {
                 layoutFixed(renderer, child);
                 childShouldPass = true;
             }
 
             if (!childShouldPass) {
                 currentColumnWithoutAbsoluteCount++;
-                if(!CSS_IS_UNDEFINED(childStyle->height_)) {
+                if(!CSS_IS_UNDEFINED(style->height_)) {
 
-                    totalUseHeightWithoutAbsolute += childStyle->height_ + childStyle->margin_top_ + childStyle->margin_bottom_;
+                    totalUseHeightWithoutAbsolute += style->height_ + style->margin_top_ + style->margin_bottom_;
 
                 }else{
 
-                    totalUseHeightWithoutAbsolute += child->GetMeasuredSize().height_ + childStyle->margin_top_ + childStyle->margin_bottom_;
+                    totalUseHeightWithoutAbsolute += child->GetMeasuredSize().height_ + style->margin_top_ + style->margin_bottom_;
 
                 }
             }
 
             if(totalUseHeightWithoutAbsolute <= availableHeight) {
-                int childWidth = child->GetMeasuredSize().width_ + childStyle->margin_left_ + childStyle->margin_right_;
+                int childWidth = child->GetMeasuredSize().width_ + style->margin_left_ + style->margin_right_;
                 currentLineWidth = currentLineWidth > childWidth ? currentLineWidth : childWidth;
             }
 
@@ -790,42 +790,42 @@ namespace lynx {
                 int childOriginY = itemStyle->padding_top_  + itemStyle->border_width_  + adjustHeightStart;
                 for (int i = start; i <= index; i++) {
                     LayoutObject* recalcChild = (LayoutObject*)renderer->Find(i);
-                    CSSStyle* recalcChildStyle = recalcChild->GetStyle();
+                    CSSStyle* recalcstyle = recalcChild->GetStyle();
 
                     CSSStyleType align = itemStyle->flex_align_items_;
 
-                    if(recalcChildStyle->visible_ == CSS_HIDDEN ||
-                            recalcChildStyle->css_display_type_ == CSS_DISPLAY_NONE) {
+                    if(recalcstyle->visible_ == CSS_HIDDEN ||
+                            recalcstyle->css_display_type_ == CSS_DISPLAY_NONE) {
                         recalcChild->Layout(0,0,0,0);
                         continue;
                     }
-                    if(recalcChildStyle->css_position_type_ == CSS_POSITION_ABSOLUTE ||
-                            recalcChildStyle->css_position_type_ == CSS_POSITION_FIXED) {
+                    if(recalcstyle->css_position_type_ == CSS_POSITION_ABSOLUTE ||
+                            recalcstyle->css_position_type_ == CSS_POSITION_FIXED) {
                         continue;
                     }
 
-                    if(recalcChildStyle->flex_align_self_ != CSSFLEX_ALIGN_AUTO) {
-                        align = recalcChildStyle->flex_align_self_;
+                    if(recalcstyle->flex_align_self_ != CSSFLEX_ALIGN_AUTO) {
+                        align = recalcstyle->flex_align_self_;
                     }
 
                     int oldChildOriginX = childOriginX;
 
-                    childOriginX += recalcChildStyle->margin_left_;
+                    childOriginX += recalcstyle->margin_left_;
                     if(i >= start)
-                        childOriginY += recalcChildStyle->margin_top_ + adjustHeightInterval;
+                        childOriginY += recalcstyle->margin_top_ + adjustHeightInterval;
 
                     int adjustX = 0;
                     int adjustWidth = CSS_UNDEFINED;
                     if(align == CSSFLEX_ALIGN_FLEX_START) {
                         //do nothing
                     }else if(align == CSSFLEX_ALIGN_FLEX_END) {
-                        adjustX = currentLineWidth - recalcChildStyle->margin_right_ - recalcChild->GetMeasuredSize().width_;
+                        adjustX = currentLineWidth - recalcstyle->margin_right_ - recalcChild->GetMeasuredSize().width_;
                     }else if(align == CSSFLEX_ALIGN_STRETCH) {
-                        adjustWidth = currentLineWidth - recalcChildStyle->margin_right_ - recalcChildStyle->margin_left_;
+                        adjustWidth = currentLineWidth - recalcstyle->margin_right_ - recalcstyle->margin_left_;
                         adjustWidth = recalcChild->GetStyle()->ClampWidth(adjustWidth);
                     }else if(align == CSSFLEX_ALIGN_CENTER) {
-                        adjustX = (currentLineWidth - recalcChildStyle->margin_right_ -
-                                recalcChildStyle->margin_left_ - recalcChild->GetMeasuredSize().width_)/2;
+                        adjustX = (currentLineWidth - recalcstyle->margin_right_ -
+                                recalcstyle->margin_left_ - recalcChild->GetMeasuredSize().width_)/2;
                     }
 
 
@@ -838,8 +838,8 @@ namespace lynx {
                     recalcChild->Layout(l, t, r, b);
 
                     childOriginX = oldChildOriginX;
-                    childOriginY += recalcChild->GetMeasuredSize().height_ + recalcChildStyle->margin_bottom_;
-                    int childItewidth_ = (r-l) + recalcChildStyle->margin_left_ + recalcChildStyle->margin_right_;
+                    childOriginY += recalcChild->GetMeasuredSize().height_ + recalcstyle->margin_bottom_;
+                    int childItewidth_ = (r-l) + recalcstyle->margin_left_ + recalcstyle->margin_right_;
                     maxWidth = maxWidth < childItewidth_ ? childItewidth_ : maxWidth;
                 }
                 start = index + 1;
@@ -866,17 +866,17 @@ namespace lynx {
         if(itemStyle->flex_wrap_ == CSSFLEX_NOWRAP) {
             for (int i = 0, size = renderer->GetChildCount(); i < size; i++) {
                 LayoutObject* child = (LayoutObject*)renderer->Find(i);
-                CSSStyle* childStyle = child->GetStyle();
-                if(childStyle->visible_ == CSS_HIDDEN ||
-                        childStyle->css_display_type_ == CSS_DISPLAY_NONE) {
+                CSSStyle* style = child->GetStyle();
+                if(style->visible_ == CSS_HIDDEN ||
+                        style->css_display_type_ == CSS_DISPLAY_NONE) {
                     child->Layout(0, 0, 0, 0);
                     continue;
                 }
-                if(childStyle->css_position_type_ == CSS_POSITION_ABSOLUTE) {
+                if(style->css_position_type_ == CSS_POSITION_ABSOLUTE) {
                     layoutAbsolute(renderer, child, width, height);
                     continue;
                 }
-                if(childStyle->css_position_type_ == CSS_POSITION_FIXED) {
+                if(style->css_position_type_ == CSS_POSITION_FIXED) {
                     layoutFixed(renderer, child);
                     continue;
                 }
@@ -913,28 +913,28 @@ namespace lynx {
             int childOriginY = itemStyle->padding_top_  + itemStyle->border_width_ + adjustHeightStart;
             for (int i = 0, size = renderer->GetChildCount(); i < size; i++) {
                 LayoutObject* child = (LayoutObject*)renderer->Find(i);
-                CSSStyle* childStyle = child->GetStyle();
+                CSSStyle* style = child->GetStyle();
 
                 CSSStyleType align = itemStyle->flex_align_items_;
 
-                if(childStyle->visible_ == CSS_HIDDEN) {
+                if(style->visible_ == CSS_HIDDEN) {
                     child->Layout(0,0,0,0);
                     continue;
                 }
-                if(childStyle->css_position_type_ == CSS_POSITION_ABSOLUTE ||
-                        childStyle->css_position_type_ == CSS_POSITION_FIXED ||
-                        childStyle->css_display_type_ == CSS_DISPLAY_NONE) {
+                if(style->css_position_type_ == CSS_POSITION_ABSOLUTE ||
+                        style->css_position_type_ == CSS_POSITION_FIXED ||
+                        style->css_display_type_ == CSS_DISPLAY_NONE) {
                     firstShowIndex++;
                     continue;
                 }
 
-                if(childStyle->flex_align_self_ != CSSFLEX_ALIGN_AUTO) {
-                    align = childStyle->flex_align_self_;
+                if(style->flex_align_self_ != CSSFLEX_ALIGN_AUTO) {
+                    align = style->flex_align_self_;
                 }
                 int oldChildOriginX = childOriginX;
 
-                childOriginX += childStyle->margin_left_;
-                childOriginY += childStyle->margin_top_;
+                childOriginX += style->margin_left_;
+                childOriginY += style->margin_top_;
                 if(i > firstShowIndex)
                     childOriginY += adjustHeightInterval;
 
@@ -943,15 +943,15 @@ namespace lynx {
                 if(align == CSSFLEX_ALIGN_FLEX_START) {
                     //do nothing
                 }else if(align == CSSFLEX_ALIGN_FLEX_END) {
-                    adjustX = availableWidth - childStyle->margin_right_
+                    adjustX = availableWidth - style->margin_right_
                             - child->GetMeasuredSize().width_;
                 }else if(align == CSSFLEX_ALIGN_STRETCH) {
-                    if (CSS_IS_UNDEFINED(childStyle->width_)) {
-                        adjustWidth = availableWidth - childStyle->margin_right_ - childStyle->margin_left_;
+                    if (CSS_IS_UNDEFINED(style->width_)) {
+                        adjustWidth = availableWidth - style->margin_right_ - style->margin_left_;
                         adjustWidth = child->GetStyle()->ClampWidth(adjustWidth);
                     }
                 }else if(align == CSSFLEX_ALIGN_CENTER) {
-                    adjustX = (availableWidth  - childStyle->margin_right_ - childStyle->margin_left_
+                    adjustX = (availableWidth  - style->margin_right_ - style->margin_left_
                             - child->GetMeasuredSize().width_)/2;
                 }
 
@@ -964,7 +964,7 @@ namespace lynx {
                 child->Layout(l,t,r,b);
 
                 childOriginX = oldChildOriginX;
-                childOriginY += child->GetMeasuredSize().height_ + childStyle->margin_bottom_;
+                childOriginY += child->GetMeasuredSize().height_ + style->margin_bottom_;
             }
         }else {
             layoutColumnWrap(renderer, width, height);
@@ -972,19 +972,18 @@ namespace lynx {
     }
 
     void CSSStaticLayout::measureAbsolute(LayoutObject* renderer, int width, int height) {
-        int w = CSS_IS_UNDEFINED(renderer->GetStyle()->width_)
-                ? width : renderer->GetStyle()->width_;
-        int h = CSS_IS_UNDEFINED(renderer->GetStyle()->height_)
-                ? height : renderer->GetStyle()->height_;
-        Size size = renderer->Measure(w, h);
-        //renderer->SetMeasuredSize(size);
+        int w = (int) (CSS_IS_UNDEFINED(renderer->GetStyle()->width_)
+                        ? width : renderer->GetStyle()->width_);
+        int h = (int) (CSS_IS_UNDEFINED(renderer->GetStyle()->height_)
+                        ? height : renderer->GetStyle()->height_);
+        renderer->Measure(w, h);
     }
 
     void CSSStaticLayout::measureFixed(LayoutObject* renderer) {
         int width = static_cast<RenderObject*>(renderer)->render_tree_host()->view_port().width_;
         int height = static_cast<RenderObject*>(renderer)->render_tree_host()->view_port().height_;
-        renderer->Measure(width, height);
-        //renderer->SetMeasuredSize(renderer->Measure(width, height));
+        renderer->Measure(Size::Descriptor::Make(width, Size::Descriptor::AT_MOST),
+                          Size::Descriptor::Make(height, Size::Descriptor::AT_MOST));
     }
 
     void CSSStaticLayout::layoutAbsolute(LayoutObject* parent, LayoutObject* renderer,  int width, int height) {
@@ -1007,50 +1006,152 @@ namespace lynx {
         double t = 0;
         double b = 0;
 
-        if (!CSS_IS_UNDEFINED(style->left_) && !CSS_IS_UNDEFINED(style->right_)) {
+        int offsetLeft = (int) (style->margin_left_ + parentStyle->border_width_);
+        int offsetRight = (int) (style->margin_right_ + parentStyle->border_width_);
+        int offsetTop = (int) (style->margin_top_ + parentStyle->border_width_);
+        int offsetBottom = (int) (style->margin_bottom_ + parentStyle->border_width_);
+
+        if (CSS_IS_UNDEFINED(style->left_) && CSS_IS_UNDEFINED(style->right_)) {
+
+            int adjust = CalculateOffsetWithFlexContainerStyle(parent,
+                                                               renderer,
+                                                               width,
+                                                               CSS_UNDEFINED);
+
+            l = adjust + offsetLeft + parentStyle->padding_left_;
+            r = l + renderer->measured_size_.width_;
+
+        } else if (!CSS_IS_UNDEFINED(style->left_) && !CSS_IS_UNDEFINED(style->right_)) {
             if (CSS_IS_UNDEFINED(style->width_)) {
-                l = style->left_ + style->margin_left_ + parentStyle->border_width_;
-                r = width - style->right_ - style->margin_right_ + parentStyle->border_width_;
+                l = style->left_ + offsetLeft;
+                r = width - style->right_ - offsetRight;
                 if (l > r) {
                     r = l;
                 }
             } else {
-                l = style->left_ + style->margin_left_ + parentStyle->border_width_;
-                r = l + renderer->GetMeasuredSize().width_;
+                l = style->left_ + offsetLeft;
+                r = l + renderer->measured_size_.width_;
             }
         } else if(!CSS_IS_UNDEFINED(style->left_)) {
-            l = style->left_ + style->margin_left_ + parentStyle->border_width_;
-            r = l + renderer->GetMeasuredSize().width_;
+            l = style->left_ + offsetLeft;
+            r = l + renderer->measured_size_.width_;
         } else if(!CSS_IS_UNDEFINED(style->right_)) {
-            r = width - style->right_ - style->margin_right_ - parentStyle->border_width_;
-            l = r - renderer->GetMeasuredSize().width_;
+            r = width - style->right_ - offsetRight;
+            l = r - renderer->measured_size_.width_;
         } else {
-            l = l + style->margin_left_ + parentStyle->border_width_;
-            r = l + renderer->GetMeasuredSize().width_;
+            l = l + offsetLeft;
+            r = l + renderer->measured_size_.width_;
         }
 
-        if (!CSS_IS_UNDEFINED(style->top_) && !CSS_IS_UNDEFINED(style->bottom_)) {
+        if (CSS_IS_UNDEFINED(style->top_) && CSS_IS_UNDEFINED(style->bottom_)) {
+
+            int adjust = CalculateOffsetWithFlexContainerStyle(parent,
+                                                               renderer,
+                                                               CSS_UNDEFINED,
+                                                               (int) height);
+
+            t = adjust + offsetTop + parentStyle->padding_top_;
+            b = t + renderer->measured_size_.height_;
+
+        } else if (!CSS_IS_UNDEFINED(style->top_) && !CSS_IS_UNDEFINED(style->bottom_)) {
             if (CSS_IS_UNDEFINED(style->height_)) {
-                t = style->top_ + style->margin_top_ + parentStyle->border_width_;
-                b = height - style->bottom_ - style->margin_bottom_ + parentStyle->border_width_;
+                t = style->top_ + offsetTop;
+                b = height - style->bottom_ - offsetBottom;
                 if (t > b) {
                     b = t;
                 }
             } else {
-                t = style->top_ + style->margin_top_ + parentStyle->border_width_;
-                b = t + renderer->GetMeasuredSize().height_;
+                t = style->top_ + offsetTop;
+                b = t + renderer->measured_size_.height_;
             }
         } else if(!CSS_IS_UNDEFINED(style->top_)) {
-            t = style->top_ + style->margin_top_ + parentStyle->border_width_;
-            b = t + renderer->GetMeasuredSize().height_;
+            t = style->top_ + offsetTop;
+            b = t + renderer->measured_size_.height_;
         } else if(!CSS_IS_UNDEFINED(style->bottom_)) {
-            b = height - style->bottom_ - style->margin_bottom_ - parentStyle->border_width_;
-            t = b - renderer->GetMeasuredSize().height_;
+            b = height - style->bottom_ - offsetBottom;
+            t = b - renderer->measured_size_.height_;
         } else {
-            t = t + style->margin_top_ + parentStyle->border_width_;
-            b = t + renderer->GetMeasuredSize().height_;
+            t = t + offsetTop;
+            b = t + renderer->measured_size_.height_;
         }
 
         renderer->Layout((int) l, (int) t, (int) r, (int) b);
+    }
+
+    int CSSStaticLayout::CalculateOffsetWithFlexContainerStyle(LayoutObject *parent,
+                                                               LayoutObject *child,
+                                                               int width,
+                                                               int height) {
+
+        int offset = 0;
+        bool isWidthAvailable = !CSS_IS_UNDEFINED(width);
+
+        CSSStyle* parentStyle = parent->GetStyle();
+        CSSStyle* style = child->GetStyle();
+
+        int availableWidth = CSS_UNDEFINED;
+        int availableHeight = CSS_UNDEFINED;
+
+        if (isWidthAvailable) {
+
+            availableWidth = (int) (width - parentStyle->padding_left_
+                                    - parentStyle->padding_right_
+                                    - parentStyle->border_width_ * 2);
+
+        } else {
+            availableHeight = (int) (height - parentStyle->padding_top_
+                                     - parentStyle->padding_bottom_
+                                     - parentStyle->border_width_ * 2);
+        }
+
+        bool isMainAxis =
+                (isWidthAvailable
+                 && parentStyle->flex_direction_ == CSSFLEX_DIRECTION_ROW)
+                ||
+                (!isWidthAvailable
+                 && parentStyle->flex_direction_ == CSSFLEX_DIRECTION_COLUMN);
+
+        int availableTargetAxis, childSizeOnTargetAxis;
+
+        if (isWidthAvailable) {
+            availableTargetAxis = availableWidth;
+            childSizeOnTargetAxis = child->measured_size_.width_;
+        } else {
+            availableTargetAxis = availableHeight;
+            childSizeOnTargetAxis = child->measured_size_.height_;
+        }
+
+        if (isMainAxis) {
+            // Main axis
+            if (parentStyle->flex_justify_content_ == CSSFLEX_JUSTIFY_FLEX_START
+                || parentStyle->flex_justify_content_ == CSSFLEX_JUSTIFY_SPACE_BETWEEN) {
+                //no action
+            } else if (parentStyle->flex_justify_content_ == CSSFLEX_JUSTIFY_FLEX_END) {
+                offset = availableTargetAxis - childSizeOnTargetAxis;
+            } else if (parentStyle->flex_justify_content_ == CSSFLEX_JUSTIFY_FLEX_CENTER
+                       || parentStyle->flex_justify_content_ == CSSFLEX_JUSTIFY_SPACE_AROUND) {
+                offset = (availableTargetAxis - childSizeOnTargetAxis) / 2;
+            }
+
+        } else {
+            // Cross axis
+            CSSStyleType align = parentStyle->flex_align_items_;
+
+            if (style->flex_align_self_ != CSSFLEX_ALIGN_AUTO) {
+                align = style->flex_align_self_;
+            }
+
+            if (parentStyle->flex_align_items_ == CSSFLEX_ALIGN_FLEX_START) {
+                //do nothing
+            } else if (align == CSSFLEX_ALIGN_FLEX_END) {
+                offset = availableTargetAxis - childSizeOnTargetAxis;
+            } else if (align == CSSFLEX_ALIGN_STRETCH) {
+                // Nothing to do when position: absolute/fixed
+            } else if (align == CSSFLEX_ALIGN_CENTER) {
+                offset = (availableTargetAxis - childSizeOnTargetAxis) / 2;
+            }
+        }
+
+        return offset;
     }
 }

--- a/lynx/layout/css_layout.h
+++ b/lynx/layout/css_layout.h
@@ -45,6 +45,11 @@ class CSSStaticLayout {
     static void layoutFixedOrAbsolute(LayoutObject* parent,
                                     LayoutObject* renderer,
                                     double width, double height);
+
+    static int CalculateOffsetWithFlexContainerStyle(LayoutObject *parent,
+                                                     LayoutObject *child,
+                                                     int width,
+                                                     int height);
 };
 }  // namespace lynx
 

--- a/lynx/layout/layout_object.cpp
+++ b/lynx/layout/layout_object.cpp
@@ -24,9 +24,8 @@ void LayoutObject::RemoveChild(ContainerNode* child) {
     Dirty();
 }
 
-
 base::Size LayoutObject::Measure(int width, int height) {
-    if (IsDirty()) {
+    if (ShouldRemeasure(width, height) || IsDirty()) {
         measured_size_ = CSSStaticLayout::Measure(this, width, height);
         return measured_size_;
     }
@@ -34,7 +33,7 @@ base::Size LayoutObject::Measure(int width, int height) {
 }
 
 void LayoutObject::Layout(int left, int top, int right, int bottom) {
-    if (IsDirty()) {
+    if (measured_position_.Reset(left, top, right, bottom) || IsDirty()) {
         CSSStaticLayout::Layout(this, right - left, bottom - top);
         layout_state_ = LAYOUT_STATE_UP_TO_DATE;
     }
@@ -55,5 +54,15 @@ void LayoutObject::UpToDate() {
 
 bool LayoutObject::IsDirty() {
     return layout_state_ == LAYOUT_STATE_DIRTY;
+}
+
+bool LayoutObject::ShouldRemeasure(int width, int height) {
+    if (last_measured_height_from_parent_ != height
+            || last_measured_width_from_parent_ != width) {
+        last_measured_height_from_parent_ = height;
+        last_measured_width_from_parent_ = width;
+        return true;
+    }
+    return false;
 }
 }  // namespace lynx

--- a/lynx/layout/layout_object.h
+++ b/lynx/layout/layout_object.h
@@ -44,7 +44,7 @@ class LayoutObject : public ContainerNode {
 
     bool IsDirty();
 
-
+    bool ShouldRemeasure(int width, int height);
 
     base::Size measured_size_;
     base::Position measured_position_;
@@ -52,6 +52,10 @@ class LayoutObject : public ContainerNode {
     LAYOUT_STATE layout_state_;
 
     CSSStyle style_;
+
+private:
+    int last_measured_width_from_parent_;
+    int last_measured_height_from_parent_;
 };
 }  // namespace lynx
 

--- a/lynx/render/android/label_measurer_android.cpp
+++ b/lynx/render/android/label_measurer_android.cpp
@@ -47,9 +47,9 @@ base::Size LabelMeasurer::MeasureLabelSizeAndSetTextLayout(RenderObject *render_
     JNIEnv *env = base::android::AttachCurrentThread();
     base::Size measured_size = MeasureLabelSize(render_object, size, text);
 
-    jscore::LynxValue *data = jscore::LynxValue::MakePlatformValue(
+    auto data = jscore::LynxValue::MakePlatformValue(
             lynx_new jscore::PlatformValue(env, Java_LabelMeasurer_getTextLayout(env).Get()));
-    render_object->SetData(RenderObject::TEXT_LAYOUT, jscore::LynxValue::MakeValueScoped(data));
+    render_object->SetData(RenderObject::TEXT_LAYOUT, data);
 
     base::android::CheckException(env);
     return measured_size;

--- a/lynx/render/android/render_object_impl_android.cpp
+++ b/lynx/render/android/render_object_impl_android.cpp
@@ -209,12 +209,12 @@ void RenderObjectImplAndroid::DispatchEvent(
     jstring event,
     jobjectArray args) {
     std::string event_str = base::android::JNIHelper::ConvertToString(env, event);
-    jscore::LynxArray* array = base::android::JNIHelper::ConvertToLynxArray(env, args);
-    base::ScopedPtr<jscore::LynxArray> scoped_args(array);
+    base::ScopedPtr<jscore::LynxArray> array =
+            base::android::JNIHelper::ConvertToLynxArray(env, args);
     if (render_object_weak_ptr_.IsValid()) {
         render_object_weak_ptr_->DispatchEvent(
                 event_str,
-                scoped_args);
+                array);
     }
 }
 
@@ -222,8 +222,7 @@ void RenderObjectImplAndroid::UpdateData(JNIEnv *env,
                                          jint attr,
                                          jobject value) {
     base::ScopedPtr<jscore::LynxValue> value_transformed =
-            jscore::LynxValue::MakeValueScoped(
-                    base::android::JNIHelper::ConvertToLynxValue(env, value));
+            base::android::JNIHelper::ConvertToLynxValue(env, value);
     if (render_object_weak_ptr_.IsValid()) {
         render_object_weak_ptr_->UpdateData(attr, value_transformed);
     }

--- a/lynx/render/image_view.cpp
+++ b/lynx/render/image_view.cpp
@@ -20,7 +20,7 @@ ImageView::ImageView(const char *tag_name,
 }
 
 base::Size ImageView::Measure(int width, int height) {
-    if (IsDirty()) {
+    if (ShouldRemeasure(width, height) || IsDirty()) {
         if (!CSS_IS_UNDEFINED(style_.height())) {
             measured_size_.height_ = style_.height();
         }
@@ -39,9 +39,10 @@ void ImageView::SetAttribute(const std::string &key, const std::string &value) {
 
     if(key.compare(kImageSrcAttribute) == 0) {
         RenderObject::SetAttribute(key, render_tree_host_->page_location() + value);
-    }else{
+    } else {
         RenderObject::SetAttribute(key, value);
     }
+
 }
 
 }  // namespace lynx

--- a/lynx/render/ios/label_measurer_ios.mm
+++ b/lynx/render/ios/label_measurer_ios.mm
@@ -22,14 +22,12 @@ namespace lynx {
         
         CSSStyle style = render_object->style_;
         NSString* label_text = [[NSString alloc]initWithUTF8String:text.c_str()];
-        
         UIFont* ui_font;
         if (style.font_weight_ == lynx::CSSTEXT_FONT_WEIGHT_BOLD) {
-            ui_font = [UIFont boldSystemFontOfSize:(style.font_size_)];
+            ui_font = [UIFont boldSystemFontOfSize:style.font_size_];
         } else {
             ui_font = [UIFont systemFontOfSize:style.font_size_];
         }
-        
         NSMutableParagraphStyle* font_style = [[NSMutableParagraphStyle alloc] init];
         NSMutableDictionary* font_attribution = [[NSMutableDictionary alloc] init];
         

--- a/lynx/render/label.cpp
+++ b/lynx/render/label.cpp
@@ -44,7 +44,8 @@ Label::Label(jscore::ThreadManager* manager,
 }
 
 base::Size Label::Measure(int width, int height) {
-    if (!IsDirty()) return measured_size_;
+    if (!ShouldRemeasure(width, height) || !IsDirty())
+        return measured_size_;
     if(text_node_ == NULL) {
         return base::Size();
     }

--- a/lynx/render/render_object.cpp
+++ b/lynx/render/render_object.cpp
@@ -157,43 +157,46 @@ void RenderObject::RecalculateLayoutPosition(base::Position& position) {
 }
 
 base::Size RenderObject::Measure(int width, int height) {
-  base::Size old_size = measured_size_;
-  LayoutObject::Measure(width, height);
-  if (old_size.Update(measured_size_.width_, measured_size_.height_) &&
-      !IsInvisible()) {
-    base::Size size(base::Size::Descriptor::GetSize(measured_size_.width_),
-                    base::Size::Descriptor::GetSize(measured_size_.height_));
-    RenderCommand* cmd = lynx_new RendererSizeUpdateCommand(
-        impl(), size, RenderCommand::CMD_SET_SIZE);
-    render_tree_host_->UpdateRenderObject(cmd);
-  }
-  return measured_size_;
+    base::Size old_size = measured_size_;
+    LayoutObject::Measure(width, height);
+    if (old_size.Update(measured_size_.width_, measured_size_.height_) && !IsInvisible()) {
+        base::Size size(base::Size::Descriptor::GetSize(measured_size_.width_),
+                        base::Size::Descriptor::GetSize(measured_size_.height_));
+        RenderCommand* cmd = lynx_new RendererSizeUpdateCommand(impl(),
+                                                                size,
+                                                                RenderCommand::CMD_SET_SIZE);
+        render_tree_host_->UpdateRenderObject(cmd);
+    }
+    return measured_size_;
 }
 
 void RenderObject::Layout(int left, int top, int right, int bottom) {
-  offset_top_ = top;
-  offset_left_ = left;
-  offset_height_ = bottom - top;
-  offset_width_ = right - left;
+    offset_top_ = top;
+    offset_left_ = left;
+    offset_height_ = bottom - top;
+    offset_width_ = right - left;
 
-  if (measured_position_.Reset(left, top, right, bottom) && !IsInvisible()) {
-    base::Position position(measured_position_);
-    RecalculateLayoutPosition(position);
-    RenderCommand* cmd = lynx_new RendererPosUpdateCommand(
-        impl(), position, RenderCommand::CMD_SET_POSITION);
-    render_tree_host_->UpdateRenderObject(cmd);
-  }
-  LayoutObject::Layout(left, top, right, bottom);
+    if (measured_position_.NeedToReset(left, top, right, bottom) && !IsInvisible()) {
+        base::Position position(left, top, right, bottom);
+        RecalculateLayoutPosition(position);
+        RenderCommand* cmd = lynx_new RendererPosUpdateCommand(impl(),
+                                                               position,
+                                                               RenderCommand::CMD_SET_POSITION);
+        render_tree_host_->UpdateRenderObject(cmd);
+    }
+    LayoutObject::Layout(left, top, right, bottom);
 }
 
 void RenderObject::SetText(const std::string& text) {
-  text_ = text;
-  if (!IsInvisible()) {
-    RenderCommand* cmd = lynx_new RendererAttrUpdateCommand(
-        impl(), "", text, RenderCommand::CMD_SET_LABEL_TEXT);
-    render_tree_host_->UpdateRenderObject(cmd);
-  }
-  Dirty();
+    text_ = text;
+    if (!IsInvisible()) {
+        RenderCommand* cmd = lynx_new RendererAttrUpdateCommand(impl(),
+                                                                "",
+                                                                text,
+                                                                RenderCommand::CMD_SET_LABEL_TEXT);
+        render_tree_host_->UpdateRenderObject(cmd);
+    }
+    Dirty();
 }
 
 void RenderObject::AppendChild(RenderObject* child) {

--- a/lynx/render/render_object.cpp
+++ b/lynx/render/render_object.cpp
@@ -272,15 +272,13 @@ void RenderObject::FlushStyle() {
 }
 
 void RenderObject::SetScrollLeft(int scroll_left) {
-  base::ScopedPtr<jscore::LynxValue> param = jscore::LynxValue::MakeValueScoped(
-      jscore::LynxValue::MakeInt(scroll_left));
-  SetData(RENDER_OBJECT_ATTRS::SCROLL_LEFT, param);
+    base::ScopedPtr<jscore::LynxValue> param = jscore::LynxValue::MakeInt(scroll_left);
+    SetData(RENDER_OBJECT_ATTRS::SCROLL_LEFT, param);
 }
 
 void RenderObject::SetScrollTop(int scroll_top) {
-  base::ScopedPtr<jscore::LynxValue> param = jscore::LynxValue::MakeValueScoped(
-      jscore::LynxValue::MakeInt(scroll_top));
-  SetData(RENDER_OBJECT_ATTRS::SCROLL_TOP, param);
+    base::ScopedPtr<jscore::LynxValue> param = jscore::LynxValue::MakeInt(scroll_top);
+    SetData(RENDER_OBJECT_ATTRS::SCROLL_TOP, param);
 }
 
 void RenderObject::UpdateData(int key,

--- a/lynx/render/swiper_view.cpp
+++ b/lynx/render/swiper_view.cpp
@@ -18,6 +18,8 @@ SwiperView::SwiperView(
 }
 
 base::Size SwiperView::Measure(int width, int height) {
+    if (!ShouldRemeasure(width, height) || !IsDirty())
+        return measured_size_;
     measured_size_.height_ = 0;
     measured_size_.width_ = 0;
     base::Size measured_size;

--- a/lynx/runtime/android/jni_runtime_bridge.cpp
+++ b/lynx/runtime/android/jni_runtime_bridge.cpp
@@ -107,8 +107,7 @@ void AddJavascriptInterface(JNIEnv* env,
     jscore::Runtime* runtime_ptr = reinterpret_cast<jscore::Runtime*>(runtime);
     if (runtime_ptr == NULL) return;
     runtime_ptr->AddJavaScriptInterface(base::android::JNIHelper::ConvertToString(env, name),
-                                        base::android::JNIHelper::ConvertToLynxFunctionObject(env,
-                                                                                              object));
+                    base::android::JNIHelper::ConvertToLynxFunctionObject(env, object).Release());
 }
 
 void CheckMemoryLeak(JNIEnv* env, jclass jcaller) {

--- a/lynx/runtime/base/lynx_function_object_android.cpp
+++ b/lynx/runtime/base/lynx_function_object_android.cpp
@@ -12,8 +12,7 @@ namespace jscore {
             : java_object_(env, java_object) {
         base::android::ScopedLocalJavaRef<jobject> scoped_java_object
                 = Java_LynxFunctionObject_getMethodNameArray(env, java_object);
-        base::ScopedPtr<LynxArray> array = LynxValue::MakeArrayScoped(
-                base::android::JNIHelper::ConvertToLynxArray(env, scoped_java_object.Get()));
+        base::ScopedPtr<LynxArray> array = base::android::JNIHelper::ConvertToLynxArray(env, scoped_java_object.Get());
         for (int i = 0; i < array->Size(); ++i) {
             LynxValue* value = array->Get(i);
             assert(value->type_ == LynxValue::Type::VALUE_STRING);
@@ -49,9 +48,8 @@ namespace jscore {
                                              java_object,
                                                (jstring) java_name.Get(),
                                                (jobjectArray) args.Get());
-        jscore::LynxValue* js_result = base::android::JNIHelper::ConvertToLynxValue(env,
-                                                                                    result.Get());
-        return LynxValue::MakeValueScoped(js_result);
+        return base::android::JNIHelper::ConvertToLynxValue(env,
+                                                            result.Get());
     }
 
 }

--- a/lynx/runtime/base/lynx_object_template.cpp
+++ b/lynx/runtime/base/lynx_object_template.cpp
@@ -15,17 +15,17 @@ namespace jscore {
 
     }
 
-    void LynxObjectTemplate::RegisterMethodCallback(std::string method_name,
+    void LynxObjectTemplate::RegisterMethodCallback(const std::string& method_name,
                                                 LynxMethodCallback callback) {
         methods_[method_name] = callback;
     }
 
-    void LynxObjectTemplate::RegisterRawMethodCallback(std::string method_name,
+    void LynxObjectTemplate::RegisterRawMethodCallback(const std::string& method_name,
                                                        JSObjectCallAsFunctionCallback callback) {
         raw_methods_[method_name] = callback;
     }
 
-    void LynxObjectTemplate::RegisterAccessorCallback(std::string field_name,
+    void LynxObjectTemplate::RegisterAccessorCallback(const std::string& field_name,
                                                         LynxGetPropertyCallback get_callback,
                                                         LynxSetPropertyCallback set_callback) {
         Field field;
@@ -38,7 +38,8 @@ namespace jscore {
         fields_[field_name] = field;
     }
 
-    base::ScopedPtr<LynxValue> LynxObjectTemplate::MethodCallback(std::string name, base::ScopedPtr<LynxArray> value) {
+    base::ScopedPtr<LynxValue>
+    LynxObjectTemplate::MethodCallback(const std::string& name, base::ScopedPtr<LynxArray>& value) {
         auto it = methods_.find(name);
         if (it != methods_.end()) {
             LynxMethodCallback callback = it->second;
@@ -47,7 +48,8 @@ namespace jscore {
         return base::ScopedPtr<LynxValue>();
     }
 
-    void LynxObjectTemplate::SetPropertyCallback(std::string name, base::ScopedPtr<LynxValue> value) {
+    void LynxObjectTemplate::SetPropertyCallback(const std::string& name,
+                                                 base::ScopedPtr<LynxValue> value) {
         auto it = fields_.find(name);
         if (it != fields_.end()) {
             Field field = it->second;
@@ -58,7 +60,7 @@ namespace jscore {
         }
     }
 
-    base::ScopedPtr<LynxValue> LynxObjectTemplate::GetPropertyCallback(std::string name) {
+    base::ScopedPtr<LynxValue> LynxObjectTemplate::GetPropertyCallback(const std::string& name) {
         auto it = fields_.find(name);
         if (it != fields_.end()) {
             Field field = it->second;

--- a/lynx/runtime/base/lynx_object_template.h
+++ b/lynx/runtime/base/lynx_object_template.h
@@ -20,7 +20,7 @@ namespace jscore {
     public:
 
         typedef base::ScopedPtr<jscore::LynxValue> (*LynxMethodCallback)
-                (jscore::LynxObjectTemplate*, base::ScopedPtr<jscore::LynxArray>);
+                (jscore::LynxObjectTemplate*, base::ScopedPtr<jscore::LynxArray>&);
         typedef base::ScopedPtr<jscore::LynxValue> (*LynxGetPropertyCallback)
                 (jscore::LynxObjectTemplate*);
         typedef void (*LynxSetPropertyCallback)
@@ -33,17 +33,18 @@ namespace jscore {
 
         LynxObjectTemplate();
         virtual ~LynxObjectTemplate();
-        void RegisterMethodCallback(std::string method_name,
+        void RegisterMethodCallback(const std::string& method_name,
                                     LynxMethodCallback callback);
-        void RegisterRawMethodCallback(std::string method_name,
+        void RegisterRawMethodCallback(const std::string& method_name,
                                        JSObjectCallAsFunctionCallback callback);
-        void RegisterAccessorCallback(std::string field_name,
+        void RegisterAccessorCallback(const std::string& field_name,
                                      LynxGetPropertyCallback get_callback,
                                      LynxSetPropertyCallback set_callback);
 
-        base::ScopedPtr<LynxValue> MethodCallback(std::string name, base::ScopedPtr<LynxArray> value);
-        void SetPropertyCallback(std::string name, base::ScopedPtr<LynxValue> value);
-        base::ScopedPtr<LynxValue> GetPropertyCallback(std::string name);
+        base::ScopedPtr<LynxValue> MethodCallback(const std::string& name,
+                                                  base::ScopedPtr<LynxArray>& value);
+        void SetPropertyCallback(const std::string& name, base::ScopedPtr<LynxValue> value);
+        base::ScopedPtr<LynxValue> GetPropertyCallback(const std::string& name);
 
         inline void set_class_name(std::string class_name) {
             class_name_ = class_name;

--- a/lynx/runtime/base/lynx_value.h
+++ b/lynx/runtime/base/lynx_value.h
@@ -50,80 +50,89 @@ namespace jscore {
             PlatformValue* platform_value;
         } data_;
 
-        inline static LynxValue* MakeBool(bool value) {
-            LynxValue *lynx_value = lynx_new LynxValue(LynxValue::Type::VALUE_BOOL);
+        inline static base::ScopedPtr<LynxValue> MakeBool(bool value) {
+            base::ScopedPtr<LynxValue> lynx_value(lynx_new LynxValue(LynxValue::Type::VALUE_BOOL));
             lynx_value->data_.b = value;
             return lynx_value;
         }
 
-        inline static LynxValue* MakeLong(long value) {
-            LynxValue *lynx_value = lynx_new LynxValue(LynxValue::Type::VALUE_LONG);
+        inline static base::ScopedPtr<LynxValue> MakeLong(long value) {
+            base::ScopedPtr<LynxValue> lynx_value(lynx_new LynxValue(LynxValue::Type::VALUE_LONG));
             lynx_value->data_.l = value;
             return lynx_value;
         }
 
-        inline static LynxValue* MakeInt(int value) {
-            LynxValue *lynx_value = lynx_new LynxValue(LynxValue::Type::VALUE_INT);
+        inline static base::ScopedPtr<LynxValue> MakeInt(int value) {
+            base::ScopedPtr<LynxValue> lynx_value(lynx_new LynxValue(LynxValue::Type::VALUE_INT));
             lynx_value->data_.i = value;
             return lynx_value;
         }
 
-        inline static LynxValue* MakeFloat(float value) {
-            LynxValue *lynx_value = lynx_new LynxValue(LynxValue::Type::VALUE_FLOAT);
+        inline static base::ScopedPtr<LynxValue> MakeFloat(float value) {
+            base::ScopedPtr<LynxValue> lynx_value(
+                    lynx_new LynxValue(LynxValue::Type::VALUE_FLOAT));
             lynx_value->data_.f = value;
             return lynx_value;
         }
 
-        inline static LynxValue* MakeDouble(double value) {
-            LynxValue *lynx_value = lynx_new LynxValue(LynxValue::Type::VALUE_DOUBLE);
+        inline static base::ScopedPtr<LynxValue> MakeDouble(double value) {
+            base::ScopedPtr<LynxValue> lynx_value(
+                    lynx_new LynxValue(LynxValue::Type::VALUE_DOUBLE));
             lynx_value->data_.d = value;
             return lynx_value;
         }
 
-        static LynxValue* MakeString(std::string& value) {
-            LynxValue *lynx_value = lynx_new LynxValue(LynxValue::Type::VALUE_STRING);
+        static base::ScopedPtr<LynxValue> MakeString(std::string& value) {
+            base::ScopedPtr<LynxValue> lynx_value(
+                    lynx_new LynxValue(LynxValue::Type::VALUE_STRING));
             char* str = lynx_new char[value.size() + 1];
             strcpy(str, value.c_str());
             lynx_value->data_.str = str;
             return lynx_value;
         }
 
-        static LynxValue* MakeString(const std::string& value) {
-            LynxValue *lynx_value = lynx_new LynxValue(LynxValue::Type::VALUE_STRING);
+        static base::ScopedPtr<LynxValue> MakeString(const std::string& value) {
+            base::ScopedPtr<LynxValue> lynx_value(
+                    lynx_new LynxValue(LynxValue::Type::VALUE_STRING));
             char* str = lynx_new char[value.size() + 1];
             strcpy(str, value.c_str());
             lynx_value->data_.str = str;
             return lynx_value;
         }
 
-        static LynxValue* MakeString(std::string&& value) {
-            LynxValue *lynx_value = lynx_new LynxValue(LynxValue::Type::VALUE_STRING);
+        static base::ScopedPtr<LynxValue> MakeString(std::string&& value) {
+            base::ScopedPtr<LynxValue> lynx_value(
+                    lynx_new LynxValue(LynxValue::Type::VALUE_STRING));
             char* str = lynx_new char[value.size() + 1];
             strcpy(str, value.c_str());
             lynx_value->data_.str = str;
             return lynx_value;
         }
 
-        inline static LynxValue* MakeFunctionObject(LynxFunctionObject* object) {
-            LynxValue *lynx_object = lynx_new LynxValue(LynxValue::Type::VALUE_LYNX_FUNCTION_OBJECT);
+        inline static base::ScopedPtr<LynxValue> MakeFunctionObject(LynxFunctionObject* object) {
+            base::ScopedPtr<LynxValue> lynx_object(
+                    lynx_new LynxValue(LynxValue::Type::VALUE_LYNX_FUNCTION_OBJECT));
             lynx_object->data_.lynx_function_object = object;
             return lynx_object;
         }
 
-        inline static LynxValue* MakeObjectTemplate(LynxObjectTemplate *object) {
-            LynxValue *lynx_object = lynx_new LynxValue(LynxValue::Type::VALUE_LYNX_OBJECT_TEMPLATE);
+        inline static base::ScopedPtr<LynxValue> MakeObjectTemplate(LynxObjectTemplate *object) {
+            base::ScopedPtr<LynxValue> lynx_object(
+                    lynx_new LynxValue(LynxValue::Type::VALUE_LYNX_OBJECT_TEMPLATE));
             lynx_object->data_.lynx_object_template = object;
             return lynx_object;
         }
 
-        inline static LynxValue* MakeLynxFunction(LynxFunction* function) {
-            LynxValue *lynx_value = lynx_new LynxValue(LynxValue::Type::VALUE_LYNX_FUNCTION);
+        inline static base::ScopedPtr<LynxValue> MakeLynxFunction(LynxFunction* function) {
+            base::ScopedPtr<LynxValue> lynx_value(
+                    lynx_new LynxValue(LynxValue::Type::VALUE_LYNX_FUNCTION));
             lynx_value->data_.lynx_function = function;
             return lynx_value;
         }
 
-        inline static LynxValue* MakePlatformValue(PlatformValue* platform_value) {
-            LynxValue *lynx_object = lynx_new LynxValue(LynxValue::Type::VALUE_PLATFORM);
+        inline static base::ScopedPtr<LynxValue> MakePlatformValue(PlatformValue* platform_value) {
+            base::ScopedPtr<LynxValue> lynx_object(
+                    lynx_new LynxValue(LynxValue::Type::VALUE_PLATFORM));
             lynx_object->data_.platform_value = platform_value;
             return lynx_object;
         }

--- a/lynx/runtime/console.cpp
+++ b/lynx/runtime/console.cpp
@@ -19,7 +19,7 @@ namespace jscore {
     }
 
     base::ScopedPtr<LynxValue>
-    Console::LogCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray> array) {
+    Console::LogCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray>& array) {
         if (array.Get() != NULL && array->Size() > 0) {
             if(array->Size() == 1) {
                 LOGD("lynx-js-log", "%s", JSCHelper::ConvertToString(array->Get(0)).c_str());
@@ -31,4 +31,5 @@ namespace jscore {
         }
         return base::ScopedPtr<LynxValue>(NULL);
     }
+
 }

--- a/lynx/runtime/console.h
+++ b/lynx/runtime/console.h
@@ -13,7 +13,7 @@ namespace jscore {
 
     private:
         static base::ScopedPtr<LynxValue>
-        LogCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray> array);
+        LogCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray>& array);
     };
 
 }

--- a/lynx/runtime/document.cpp
+++ b/lynx/runtime/document.cpp
@@ -54,7 +54,7 @@ namespace jscore {
     }
 
     base::ScopedPtr<LynxValue>
-    Document::QuerySelectorCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray> array) {
+    Document::QuerySelectorCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray>& array) {
         Document* document = static_cast<Document*>(object);
         if(array.Get() != NULL && array->Size() > 0) {
             std::string text = array->Get(0)->data_.str;
@@ -81,7 +81,7 @@ namespace jscore {
 
     base::ScopedPtr<LynxValue>
     Document::CreateElementCallback(LynxObjectTemplate* object,
-                                    base::ScopedPtr<LynxArray> array) {
+                                    base::ScopedPtr<LynxArray>& array) {
         Document* document = static_cast<Document*>(object);
         if (array.Get() != NULL
             && array->Size() > 0
@@ -97,13 +97,13 @@ namespace jscore {
 
     base::ScopedPtr<LynxValue>
     Document::CreateDomCallback(LynxObjectTemplate* object,
-                                base::ScopedPtr<LynxArray> array) {
+                                base::ScopedPtr<LynxArray>& array) {
         return base::ScopedPtr<LynxValue>(NULL);
     }
 
     base::ScopedPtr<LynxValue>
     Document::CreateTextNodeCallback(LynxObjectTemplate* object,
-                                base::ScopedPtr<LynxArray> array) {
+                                base::ScopedPtr<LynxArray>& array) {
         Document* document = static_cast<Document*>(object);
         if (array.Get() != NULL
             && array->Size() > 0
@@ -119,32 +119,32 @@ namespace jscore {
 
     base::ScopedPtr<LynxValue>
     Document::AddEventListenerCallback(LynxObjectTemplate* object,
-                                       base::ScopedPtr<LynxArray> array) {
+                                       base::ScopedPtr<LynxArray>& array) {
         return base::ScopedPtr<LynxValue>(NULL);
     }
 
     base::ScopedPtr<LynxValue>
     Document::RemoveEventListenerCallback(LynxObjectTemplate* object,
-                                          base::ScopedPtr<LynxArray> array) {
+                                          base::ScopedPtr<LynxArray>& array) {
 
         return base::ScopedPtr<LynxValue>(NULL);
     }
 
     base::ScopedPtr<LynxValue>
     Document::DispatchEventCallback(LynxObjectTemplate* object,
-                                    base::ScopedPtr<LynxArray> array) {
+                                    base::ScopedPtr<LynxArray>& array) {
         return base::ScopedPtr<LynxValue>(NULL);
     }
 
     base::ScopedPtr<LynxValue>
     Document::CreateEventCallback(LynxObjectTemplate* object,
-                                  base::ScopedPtr<LynxArray> array) {
+                                  base::ScopedPtr<LynxArray>& array) {
         return base::ScopedPtr<LynxValue>(NULL);
     }
 
     base::ScopedPtr<LynxValue>
     Document::GetElementByIdCallback(LynxObjectTemplate* object,
-                                     base::ScopedPtr<LynxArray> array) {
+                                     base::ScopedPtr<LynxArray>& array) {
         Document* document = static_cast<Document*>(object);
         if (array.Get() != NULL
                 && array->Size() > 0

--- a/lynx/runtime/document.cpp
+++ b/lynx/runtime/document.cpp
@@ -58,9 +58,8 @@ namespace jscore {
         Document* document = static_cast<Document*>(object);
         if(array.Get() != NULL && array->Size() > 0) {
             std::string text = array->Get(0)->data_.str;
-            LynxValue *value = LynxValue::MakeObjectTemplate(document->QuerySelector(text));
-            return base::ScopedPtr<LynxValue>(value);
-        }
+            return LynxValue::MakeObjectTemplate(document->QuerySelector(text));
+    }
         return base::ScopedPtr<LynxValue>(NULL);
     }
 
@@ -89,8 +88,7 @@ namespace jscore {
             std::string tag_name = array->Get(0)->data_.str;
             Element* element = document->CreateElement(tag_name);
 
-            LynxValue *value = LynxValue::MakeObjectTemplate(element);
-            return base::ScopedPtr<LynxValue>(value);
+            return LynxValue::MakeObjectTemplate(element);
         }
         return base::ScopedPtr<LynxValue>(NULL);
     }
@@ -111,8 +109,7 @@ namespace jscore {
             std::string text = array->Get(0)->data_.str;
             Element* element = document->CreateTextNode(text);
 
-            LynxValue *value = LynxValue::MakeObjectTemplate(element);
-            return base::ScopedPtr<LynxValue>(value);
+            return LynxValue::MakeObjectTemplate(element);
         }
         return base::ScopedPtr<LynxValue>(NULL);
     }
@@ -151,20 +148,17 @@ namespace jscore {
                 && array->Get(0)->type_ == LynxValue::Type::VALUE_STRING) {
             std::string id = array->Get(0)->data_.str;
             Element* element = document->GetElementById(id);
-            LynxValue *value = LynxValue::MakeObjectTemplate(element);
-            return base::ScopedPtr<LynxValue>(value);
+            return LynxValue::MakeObjectTemplate(element);
         }
         return base::ScopedPtr<LynxValue>(NULL);
     }
 
     base::ScopedPtr<LynxValue> Document::GetDomainCallback(LynxObjectTemplate* object) {
-        LynxValue *value = LynxValue::MakeString("");
-        return base::ScopedPtr<LynxValue>(value);
+        return LynxValue::MakeString("");
     }
 
     base::ScopedPtr<LynxValue> Document::GetCookieCallback(LynxObjectTemplate* object) {
-        LynxValue *value = LynxValue::MakeString("");
-        return base::ScopedPtr<LynxValue>(value);
+        return LynxValue::MakeString("");
     }
 
     base::ScopedPtr<LynxValue> Document::GetReadyStateCallback(LynxObjectTemplate* object) {

--- a/lynx/runtime/document.h
+++ b/lynx/runtime/document.h
@@ -24,23 +24,23 @@ namespace jscore {
         JSContext* context_;
 
         static base::ScopedPtr<LynxValue>
-        CreateElementCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray> array);
+        CreateElementCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray>& array);
         static base::ScopedPtr<LynxValue>
-        CreateDomCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray> array);
+        CreateDomCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray>& array);
         static base::ScopedPtr<LynxValue>
-        CreateTextNodeCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray> array);
+        CreateTextNodeCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray>& array);
         static base::ScopedPtr<LynxValue>
-        AddEventListenerCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray> array);
+        AddEventListenerCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray>& array);
         static base::ScopedPtr<LynxValue>
-        RemoveEventListenerCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray> array);
+        RemoveEventListenerCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray>& array);
         static base::ScopedPtr<LynxValue>
-        DispatchEventCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray> array);
+        DispatchEventCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray>& array);
         static base::ScopedPtr<LynxValue>
-        CreateEventCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray> array);
+        CreateEventCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray>& array);
         static base::ScopedPtr<LynxValue>
-        GetElementByIdCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray> array);
+        GetElementByIdCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray>& array);
         static base::ScopedPtr<LynxValue>
-        QuerySelectorCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray> array);
+        QuerySelectorCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray>& array);
 
         static base::ScopedPtr<LynxValue> GetDomainCallback(LynxObjectTemplate* object);
         static base::ScopedPtr<LynxValue> GetCookieCallback(LynxObjectTemplate* object);

--- a/lynx/runtime/element.cpp
+++ b/lynx/runtime/element.cpp
@@ -72,7 +72,7 @@ namespace jscore {
     }
 
     base::ScopedPtr<LynxValue>
-    Element::AppendChildCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray> array) {
+    Element::AppendChildCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray>& array) {
         Element *element = static_cast<Element *>(object);
         if (array.Get() != NULL && array->Size() > 0) {
             lynx::RenderObject* render_object = element->render_object();
@@ -88,7 +88,7 @@ namespace jscore {
     }
 
     base::ScopedPtr<LynxValue>
-    Element::AppendChildrenCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray> array) {
+    Element::AppendChildrenCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray>& array) {
         Element *element = static_cast<Element *>(object);
         if (array.Get() != NULL && array->Size() > 0) {
             lynx::RenderObject* render_object = element->render_object();
@@ -107,7 +107,7 @@ namespace jscore {
     }
 
     base::ScopedPtr<LynxValue>
-    Element::InsertChildAtIndexCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray> array) {
+    Element::InsertChildAtIndexCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray>& array) {
         Element *element = static_cast<Element *>(object);
         if (array.Get() != NULL && array->Size() > 1) {
             lynx::RenderObject* render_object = element->render_object();
@@ -124,7 +124,7 @@ namespace jscore {
     }
 
     base::ScopedPtr<LynxValue>
-    Element::RemoveChildByIndexCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray> array) {
+    Element::RemoveChildByIndexCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray>& array) {
         Element *element = static_cast<Element *>(object);
         if (array.Get() != NULL && array->Size() > 0) {
             lynx::RenderObject* render_parent = element->render_object();
@@ -140,7 +140,7 @@ namespace jscore {
     }
 
     base::ScopedPtr<LynxValue>
-    Element::InsertBeforeCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray> array) {
+    Element::InsertBeforeCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray>& array) {
         Element *element = static_cast<Element *>(object);
         if (array.Get() != NULL && array->Size() > 0) {
             lynx::RenderObject* render_object = element->render_object();
@@ -162,7 +162,7 @@ namespace jscore {
     }
 
     base::ScopedPtr<LynxValue>
-    Element::RemoveChildCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray> array) {
+    Element::RemoveChildCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray>& array) {
         Element *element = static_cast<Element *>(object);
         if (array.Get() != NULL && array->Size() > 0) {
             lynx::RenderObject* render_object = element->render_object();
@@ -176,7 +176,7 @@ namespace jscore {
     }
 
     base::ScopedPtr<LynxValue>
-    Element::GetChildByIndexCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray> array) {
+    Element::GetChildByIndexCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray>& array) {
         Element *element = static_cast<Element *>(object);
         if (array.Get() != NULL && array->Size() > 0) {
             lynx::RenderObject* render_object = element->render_object_.Get();
@@ -191,7 +191,7 @@ namespace jscore {
     }
 
     base::ScopedPtr<LynxValue>
-    Element::AddEventListenerCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray> array) {
+    Element::AddEventListenerCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray>& array) {
         Element *element = static_cast<Element *>(object);
         if (array.Get() != NULL && array->Size() > 1) {
             lynx::RenderObject* render_object = element->render_object();
@@ -207,7 +207,7 @@ namespace jscore {
     }
 
     base::ScopedPtr<LynxValue>
-    Element::RemoveEventListenerCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray> array) {
+    Element::RemoveEventListenerCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray>& array) {
         Element *element = static_cast<Element *>(object);
         if (array.Get() != NULL && array->Size() > 1) {
             lynx::RenderObject* render_object = element->render_object();
@@ -219,7 +219,7 @@ namespace jscore {
     }
 
     base::ScopedPtr<LynxValue>
-    Element::SetAttributionCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray> array) {
+    Element::SetAttributionCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray>& array) {
         Element *element = static_cast<Element *>(object);
         if (array.Get() != NULL
             && array->Size() > 0
@@ -236,7 +236,7 @@ namespace jscore {
     }
 
     base::ScopedPtr<LynxValue>
-    Element::SetAttributeCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray> array) {
+    Element::SetAttributeCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray>& array) {
         Element *element = static_cast<Element *>(object);
         if(array.Get() != NULL && array->Size() == 2
            && array->Get(0)->type_ == LynxValue::VALUE_STRING) {
@@ -248,7 +248,7 @@ namespace jscore {
     }
 
     base::ScopedPtr<LynxValue>
-    Element::HasAttributeCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray> array) {
+    Element::HasAttributeCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray>& array) {
         Element *element = static_cast<Element *>(object);
         if(array.Get() != NULL && array->Size() == 1) {
             lynx::RenderObject* render_object = element->render_object();
@@ -259,7 +259,7 @@ namespace jscore {
     }
 
     base::ScopedPtr<LynxValue>
-    Element::RemoveAttributeCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray> array) {
+    Element::RemoveAttributeCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray>& array) {
         Element *element = static_cast<Element *>(object);
         if(array.Get() != NULL && array->Size() == 1) {
             lynx::RenderObject* render_object = element->render_object();
@@ -269,7 +269,7 @@ namespace jscore {
     }
 
     base::ScopedPtr<LynxValue>
-    Element::SetStyleCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray> array) {
+    Element::SetStyleCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray>& array) {
         /*
         Element *element = static_cast<Element *>(object);
         lynx::RenderObject* render_object = element->render_object();
@@ -292,7 +292,7 @@ namespace jscore {
     }
 
     base::ScopedPtr<LynxValue>
-    Element::SetTextCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray> array) {
+    Element::SetTextCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray>& array) {
         Element *element = static_cast<Element *>(object);
         if(array.Get() != NULL && array->Size() > 0) {
             lynx::RenderObject* render_object = element->render_object();
@@ -303,33 +303,33 @@ namespace jscore {
     }
 
     base::ScopedPtr<LynxValue>
-    Element::GetTextCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray> array) {
+    Element::GetTextCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray>& array) {
         Element *element = static_cast<Element *>(object);
         lynx::RenderObject* render_object = element->render_object_.Get();
         return base::ScopedPtr<LynxValue>(LynxValue::MakeString(render_object->GetText().c_str()));
     }
 
     base::ScopedPtr<LynxValue>
-    Element::StartCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray> array) {
+    Element::StartCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray>& array) {
 
         return base::ScopedPtr<LynxValue>(NULL);
     }
 
     base::ScopedPtr<LynxValue>
-    Element::StopCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray> array) {
+    Element::StopCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray>& array) {
 
         return base::ScopedPtr<LynxValue>(NULL);
     }
 
     base::ScopedPtr<LynxValue>
-    Element::StopAnimateCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray> array) {
+    Element::StopAnimateCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray>& array) {
 
         return base::ScopedPtr<LynxValue>(NULL);
     }
 
     base::ScopedPtr<LynxValue>
     Element::StartAnimateWithCallbackCallback(LynxObjectTemplate* object,
-                                              base::ScopedPtr<LynxArray> array) {
+                                              base::ScopedPtr<LynxArray>& array) {
         Element *element = static_cast<Element *>(object);
         lynx::RenderObject* render_object = element->render_object();
         if (array.Get() != NULL && array->Size() > 1) {
@@ -347,19 +347,19 @@ namespace jscore {
     }
 
     base::ScopedPtr<LynxValue>
-    Element::SetPullViewCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray> array) {
+    Element::SetPullViewCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray>& array) {
 
         return base::ScopedPtr<LynxValue>(NULL);
     }
 
     base::ScopedPtr<LynxValue>
-    Element::ClosePullViewCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray> array) {
+    Element::ClosePullViewCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray>& array) {
 
         return base::ScopedPtr<LynxValue>(NULL);
     }
 
     base::ScopedPtr<LynxValue>
-    Element::HasChildNodesCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray> array) {
+    Element::HasChildNodesCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray>& array) {
         Element* element = static_cast<Element*>(object);
         lynx::RenderObject* render_object = element->render_object();
 

--- a/lynx/runtime/element.cpp
+++ b/lynx/runtime/element.cpp
@@ -338,8 +338,9 @@ namespace jscore {
             //render_object->AddEventListener(event, js_function, false);
 
             LynxObject* properties = array->Get(0)->data_.lynx_object;
-            properties->Set("name", LynxValue::MakeString(event.c_str()));
-            render_object->SetData(lynx::RenderObject::ANIMATE_PROPS, base::ScopedPtr<LynxValue>(properties));
+            properties->Set("name", LynxValue::MakeString(event.c_str()).Release());
+            render_object->SetData(lynx::RenderObject::ANIMATE_PROPS,
+                                   base::ScopedPtr<LynxValue>(properties));
             array->Release();
         }
 
@@ -368,13 +369,11 @@ namespace jscore {
 
     base::ScopedPtr<LynxValue> Element::GetTagNameCallback(LynxObjectTemplate* object) {
         Element *element = static_cast<Element *>(object);
-        LynxValue* value = LynxValue::MakeString(element->render_object()->tag_name());
-        return LynxValue::MakeValueScoped(value);
+        return LynxValue::MakeString(element->render_object()->tag_name());
     }
 
     base::ScopedPtr<LynxValue> Element::GetNodeTypeCallback(LynxObjectTemplate* object) {
-        LynxValue* value = LynxValue::MakeInt(1);
-        return LynxValue::MakeValueScoped(value);
+        return LynxValue::MakeInt(1);
     }
 
     base::ScopedPtr<LynxValue> Element::GetParentNodeCallback(LynxObjectTemplate* object) {
@@ -383,64 +382,54 @@ namespace jscore {
         lynx::RenderObject* parent = const_cast<lynx::RenderObject*>(render_object->Parent());
         if (parent) {
             Element* parent_element = static_cast<Element*>(parent->GetJSRef());
-            LynxValue *value = LynxValue::MakeObjectTemplate(parent_element);
-            return LynxValue::MakeValueScoped(value);
+            return LynxValue::MakeObjectTemplate(parent_element);
         }
         return LynxValue::MakeValueScoped(NULL);
     }
 
     base::ScopedPtr<LynxValue> Element::GetOffsetTopCallback(LynxObjectTemplate* object) {
         Element *element = static_cast<Element *>(object);
-        LynxValue* value = LynxValue::MakeInt(element->render_object()->offset_top());
-        return LynxValue::MakeValueScoped(value);
+        return LynxValue::MakeInt(element->render_object()->offset_top());
     }
 
     base::ScopedPtr<LynxValue> Element::GetOffsetLeftCallback(LynxObjectTemplate* object) {
         Element *element = static_cast<Element *>(object);
-        LynxValue* value = LynxValue::MakeInt(element->render_object()->offset_left());
-        return LynxValue::MakeValueScoped(value);
+        return LynxValue::MakeInt(element->render_object()->offset_left());
     }
 
     base::ScopedPtr<LynxValue> Element::GetOffsetWidthCallback(LynxObjectTemplate* object) {
         Element *element = static_cast<Element *>(object);
-        LynxValue* value = LynxValue::MakeInt(element->render_object()->offset_width());
-        return LynxValue::MakeValueScoped(value);
+        return LynxValue::MakeInt(element->render_object()->offset_width());
     }
 
     base::ScopedPtr<LynxValue> Element::GetOffsetHeightCallback(LynxObjectTemplate* object) {
         Element *element = static_cast<Element *>(object);
-        LynxValue* value = LynxValue::MakeInt(element->render_object()->offset_height());
-        return LynxValue::MakeValueScoped(value);
+        return LynxValue::MakeInt(element->render_object()->offset_height());
     }
 
     base::ScopedPtr<LynxValue> Element::GetScrollWidthCallback(LynxObjectTemplate* object) {
         Element *element = static_cast<Element *>(object);
-        LynxValue* value = LynxValue::MakeInt(element->render_object()->scroll_width());
-        return LynxValue::MakeValueScoped(value);
+        return LynxValue::MakeInt(element->render_object()->scroll_width());
     }
 
     base::ScopedPtr<LynxValue> Element::GetScrollHeightCallback(LynxObjectTemplate* object) {
         Element *element = static_cast<Element *>(object);
-        LynxValue* value = LynxValue::MakeInt(element->render_object()->scroll_height());
-        return LynxValue::MakeValueScoped(value);
+        return LynxValue::MakeInt(element->render_object()->scroll_height());
     }
 
     base::ScopedPtr<LynxValue> Element::GetScrollTopCallback(LynxObjectTemplate* object) {
         Element *element = static_cast<Element *>(object);
-        LynxValue* value = LynxValue::MakeInt(element->render_object()->scroll_top());
-        return LynxValue::MakeValueScoped(value);
+        return LynxValue::MakeInt(element->render_object()->scroll_top());
     }
 
     base::ScopedPtr<LynxValue> Element::GetScrollLeftCallback(LynxObjectTemplate* object) {
         Element *element = static_cast<Element *>(object);
-        LynxValue* value = LynxValue::MakeInt(element->render_object()->scroll_left());
-        return LynxValue::MakeValueScoped(value);
+        return LynxValue::MakeInt(element->render_object()->scroll_left());
     }
 
     base::ScopedPtr<LynxValue> Element::GetTextContentCallback(LynxObjectTemplate* object) {
         Element *element = static_cast<Element *>(object);
-        LynxValue* value = LynxValue::MakeString(element->render_object()->GetText());
-        return LynxValue::MakeValueScoped(value);
+        return LynxValue::MakeString(element->render_object()->GetText());
     }
 
     void Element::SetTextContentCallback(LynxObjectTemplate* object,
@@ -456,8 +445,7 @@ namespace jscore {
         lynx::RenderObject* next = render_object->NextSibling();
         if(next) {
             Element* next_element = static_cast<Element*>(next->GetJSRef());
-            LynxValue *value = LynxValue::MakeObjectTemplate(next_element);
-            return base::ScopedPtr<LynxValue>(value);
+            return LynxValue::MakeObjectTemplate(next_element);
         }
         return base::ScopedPtr<LynxValue>(NULL);
     }
@@ -471,8 +459,7 @@ namespace jscore {
                            static_cast<lynx::RenderObject*>(render_child->FirstChild())
                             : render_child;
             Element* next_element = static_cast<Element*>(render_child->GetJSRef());
-            LynxValue *value = LynxValue::MakeObjectTemplate(next_element);
-            return base::ScopedPtr<LynxValue>(value);
+            return LynxValue::MakeObjectTemplate(next_element);
         }
         return base::ScopedPtr<LynxValue>(NULL);
     }
@@ -498,7 +485,7 @@ namespace jscore {
                 child_element = static_cast<Element*>(render_child->GetJSRef());
             }
 
-            array->Push(LynxValue::MakeObjectTemplate(child_element));
+            array->Push(LynxValue::MakeObjectTemplate(child_element).Release());
             render_child = static_cast<lynx::RenderObject*>(render_child->Next());
         }
         return LynxValue::MakeValueScoped(array);

--- a/lynx/runtime/element.h
+++ b/lynx/runtime/element.h
@@ -32,51 +32,51 @@ namespace jscore {
         JSContext* context_;
 
         static base::ScopedPtr<LynxValue>
-        AppendChildCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray> array);
+        AppendChildCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray>& array);
         static base::ScopedPtr<LynxValue>
-        AppendChildrenCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray> array);
+        AppendChildrenCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray>& array);
         static base::ScopedPtr<LynxValue>
-        InsertChildAtIndexCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray> array);
+        InsertChildAtIndexCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray>& array);
         static base::ScopedPtr<LynxValue>
-        RemoveChildByIndexCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray> array);
+        RemoveChildByIndexCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray>& array);
         static base::ScopedPtr<LynxValue>
-        InsertBeforeCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray> array);
+        InsertBeforeCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray>& array);
         static base::ScopedPtr<LynxValue>
-        RemoveChildCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray> array);
+        RemoveChildCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray>& array);
         static base::ScopedPtr<LynxValue>
-        GetChildByIndexCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray> array);
+        GetChildByIndexCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray>& array);
         static base::ScopedPtr<LynxValue>
-        AddEventListenerCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray> array);
+        AddEventListenerCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray>& array);
         static base::ScopedPtr<LynxValue>
-        RemoveEventListenerCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray> array);
+        RemoveEventListenerCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray>& array);
         static base::ScopedPtr<LynxValue>
-        SetAttributionCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray> array);
+        SetAttributionCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray>& array);
         static base::ScopedPtr<LynxValue>
-        SetAttributeCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray> array);
+        SetAttributeCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray>& array);
         static base::ScopedPtr<LynxValue>
-        HasAttributeCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray> array);
+        HasAttributeCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray>& array);
         static base::ScopedPtr<LynxValue>
-        RemoveAttributeCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray> array);
+        RemoveAttributeCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray>& array);
         static base::ScopedPtr<LynxValue>
-        SetStyleCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray> array);
+        SetStyleCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray>& array);
         static base::ScopedPtr<LynxValue>
-        SetTextCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray> array);
+        SetTextCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray>& array);
         static base::ScopedPtr<LynxValue>
-        GetTextCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray> array);
+        GetTextCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray>& array);
         static base::ScopedPtr<LynxValue>
-        StartCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray> array);
+        StartCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray>& array);
         static base::ScopedPtr<LynxValue>
-        StopCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray> array);
+        StopCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray>& array);
         static base::ScopedPtr<LynxValue>
-        StopAnimateCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray> array);
+        StopAnimateCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray>& array);
         static base::ScopedPtr<LynxValue>
-        StartAnimateWithCallbackCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray> array);
+        StartAnimateWithCallbackCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray>& array);
         static base::ScopedPtr<LynxValue>
-        SetPullViewCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray> array);
+        SetPullViewCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray>& array);
         static base::ScopedPtr<LynxValue>
-        ClosePullViewCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray> array);
+        ClosePullViewCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray>& array);
         static base::ScopedPtr<LynxValue>
-        HasChildNodesCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray> array);
+        HasChildNodesCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray>& array);
 
 
         static base::ScopedPtr<LynxValue> GetTagNameCallback(LynxObjectTemplate* object);

--- a/lynx/runtime/history.cpp
+++ b/lynx/runtime/history.cpp
@@ -71,7 +71,7 @@ namespace jscore {
 
     base::ScopedPtr<LynxValue>
     History::ForwardCallback(LynxObjectTemplate* object,
-                             base::ScopedPtr<LynxArray> array) {
+                             base::ScopedPtr<LynxArray>& array) {
         History* history = static_cast<History*>(object);
         history->Forward();
         history->Load();
@@ -80,7 +80,7 @@ namespace jscore {
 
     base::ScopedPtr<LynxValue>
     History::BackCallback(LynxObjectTemplate* object,
-                             base::ScopedPtr<LynxArray> array) {
+                             base::ScopedPtr<LynxArray>& array) {
         History* history = static_cast<History*>(object);
         history->Back();
         history->Load();
@@ -89,7 +89,7 @@ namespace jscore {
 
     base::ScopedPtr<LynxValue>
     History::GoCallback(LynxObjectTemplate* object,
-                             base::ScopedPtr<LynxArray> array) {
+                             base::ScopedPtr<LynxArray>& array) {
         History* history = static_cast<History*>(object);
         if (array.Get() != NULL && array->Size() > 0) {
             LynxValue* value = array->Get(0);

--- a/lynx/runtime/history.cpp
+++ b/lynx/runtime/history.cpp
@@ -108,8 +108,7 @@ namespace jscore {
     base::ScopedPtr<LynxValue>
     History::GetLengthCallback(LynxObjectTemplate* object) {
         History* history = static_cast<History*>(object);
-        LynxValue* length = LynxValue::MakeInt(history->GetLength());
-        return LynxValue::MakeValueScoped(length);
+        return LynxValue::MakeInt(history->GetLength());
     }
     
 }

--- a/lynx/runtime/history.h
+++ b/lynx/runtime/history.h
@@ -28,13 +28,13 @@ public:
     
 private:
     static base::ScopedPtr<LynxValue>
-    ForwardCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray> array);
+    ForwardCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray>& array);
 
     static base::ScopedPtr<LynxValue>
-    BackCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray> array);
+    BackCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray>& array);
 
     static base::ScopedPtr<LynxValue>
-    GoCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray> array);
+    GoCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray>& array);
 
     static base::ScopedPtr<LynxValue> GetLengthCallback(LynxObjectTemplate* object);
 

--- a/lynx/runtime/js_event.cpp
+++ b/lynx/runtime/js_event.cpp
@@ -73,21 +73,21 @@ namespace jscore {
 
     base::ScopedPtr<LynxValue>
     JSEvent::StopPropagationCallback(LynxObjectTemplate* object,
-                                     base::ScopedPtr<LynxArray> array) {
+                                     base::ScopedPtr<LynxArray>& array) {
         static_cast<JSEvent*>(object)->StopPropagation();
         return base::ScopedPtr<LynxValue>();
     }
 
     base::ScopedPtr<LynxValue>
     JSEvent::PreventDefaultCallback(LynxObjectTemplate* object,
-                                    base::ScopedPtr<LynxArray> array) {
+                                    base::ScopedPtr<LynxArray>& array) {
         static_cast<JSEvent*>(object)->PreventDefault();
         return base::ScopedPtr<LynxValue>();
     }
 
     base::ScopedPtr<LynxValue>
     JSEvent::InitEventCallback(LynxObjectTemplate* object,
-                               base::ScopedPtr<LynxArray> array) {
+                               base::ScopedPtr<LynxArray>& array) {
         static_cast<JSEvent*>(object)->InitEvent(array->Get(0)->data_.str,
                                                  array->Get(1)->data_.b,
                                                  array->Get(2)->data_.b);

--- a/lynx/runtime/js_event.cpp
+++ b/lynx/runtime/js_event.cpp
@@ -43,32 +43,27 @@ namespace jscore {
 
     base::ScopedPtr<LynxValue> JSEvent::GetTypeCallback(LynxObjectTemplate* object) {
         std::string type = static_cast<JSEvent*>(object)->type();
-        LynxValue* value = LynxValue::MakeString(type);
-        return LynxValue::MakeValueScoped(value);
+        return LynxValue::MakeString(type);
     }
 
     base::ScopedPtr<LynxValue> JSEvent::GetBubblesCallback(LynxObjectTemplate* object) {
-        LynxValue* value = LynxValue::MakeBool(static_cast<JSEvent*>(object)->bubbles());
-        return LynxValue::MakeValueScoped(value);
+        return LynxValue::MakeBool(static_cast<JSEvent*>(object)->bubbles());
     }
 
     base::ScopedPtr<LynxValue> JSEvent::GetCancelableCallback(LynxObjectTemplate* object) {
-        LynxValue* value = LynxValue::MakeBool(static_cast<JSEvent*>(object)->cancelable());
-        return LynxValue::MakeValueScoped(value);
+        return LynxValue::MakeBool(static_cast<JSEvent*>(object)->cancelable());
     }
 
     base::ScopedPtr<LynxValue> JSEvent::GetTargetCallback(LynxObjectTemplate* object) {
         JSEvent* js_event = static_cast<JSEvent*>(object);
-        LynxValue* value = LynxValue::MakeObjectTemplate(
+        return LynxValue::MakeObjectTemplate(
                 static_cast<Element*>(js_event->target()->GetJSRef()));
-        return LynxValue::MakeValueScoped(value);
     }
 
     base::ScopedPtr<LynxValue> JSEvent::GetCurrentTargetCallback(LynxObjectTemplate* object) {
         JSEvent* js_event = static_cast<JSEvent*>(object);
-        LynxValue* value = LynxValue::MakeObjectTemplate(
+        return LynxValue::MakeObjectTemplate(
                 static_cast<Element*>(js_event->current_target()->GetJSRef()));
-        return LynxValue::MakeValueScoped(value);
     }
 
     base::ScopedPtr<LynxValue>

--- a/lynx/runtime/js_event.h
+++ b/lynx/runtime/js_event.h
@@ -61,9 +61,9 @@ namespace jscore {
         static base::ScopedPtr<LynxValue> GetCancelableCallback(LynxObjectTemplate* object);
         static base::ScopedPtr<LynxValue> GetTargetCallback(LynxObjectTemplate* object);
         static base::ScopedPtr<LynxValue> GetCurrentTargetCallback(LynxObjectTemplate* object);
-        static base::ScopedPtr<LynxValue> StopPropagationCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray> value);
-        static base::ScopedPtr<LynxValue> PreventDefaultCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray> value);
-        static base::ScopedPtr<LynxValue> InitEventCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray> value);
+        static base::ScopedPtr<LynxValue> StopPropagationCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray>& value);
+        static base::ScopedPtr<LynxValue> PreventDefaultCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray>& value);
+        static base::ScopedPtr<LynxValue> InitEventCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray>& value);
         void Reset();
 
         lynx::RenderObject* current_target_;

--- a/lynx/runtime/jsc/jsc_helper.cpp
+++ b/lynx/runtime/jsc/jsc_helper.cpp
@@ -2,6 +2,8 @@
 
 #include <sstream>
 #include <runtime/base/lynx_value.h>
+#include <string>
+#include <base/debug/timing_tracker.h>
 #include "runtime/base/lynx_value.h"
 #include "runtime/jsc/objects/object_template.h"
 #include "runtime/jsc/objects/function_object.h"
@@ -119,20 +121,19 @@ namespace jscore {
     }
     
     std::string JSCHelper::ConvertToString(JSContextRef ctx, JSValueRef value) {
-        std::string str;
         if(JSValueIsString(ctx, value) || JSValueIsObject(ctx, value)) {
             JSStringRef js_str = JSValueToStringCopy(ctx, value, NULL);
             size_t len = JSStringGetMaximumUTF8CStringSize(js_str);
             base::ScopedPtr<char[]> ch(lynx_new char[len]);
-            JSStringGetUTF8CString(js_str, ch.Get(), len);
-            str = ch.Get();
+            size_t size = JSStringGetUTF8CString(js_str, ch.Get(), len);
             JSStringRelease(js_str);
+            return std::string(ch.Get(), size - 1);
         }
-        return str;
+        return "";
     }
 
-    LynxValue* JSCHelper::ConvertToLynxValue(JSContextRef ctx, JSValueRef value) {
-        LynxValue* js_value = 0;
+    base::ScopedPtr<LynxValue> JSCHelper::ConvertToLynxValue(JSContextRef ctx, JSValueRef value) {
+        base::ScopedPtr<LynxValue> js_value;
         if (JSValueIsBoolean(ctx, value)) {
             js_value = LynxValue::MakeBool(JSValueToBoolean(ctx, value));
         } else if (JSValueIsNumber(ctx, value)) {
@@ -156,7 +157,8 @@ namespace jscore {
             }
 #endif
         } else if (JSValueIsArray(ctx, value)) {
-            js_value = ConvertToLynxArray(ctx, (JSObjectRef) value);
+            js_value = base::ScopedPtr<LynxValue>(
+                    ConvertToLynxArray(ctx, (JSObjectRef) value).Release());
         } else if (JSValueIsObject(ctx, value)) {
             if (JSObjectIsFunction(ctx, (JSObjectRef) value)) {
                 js_value = ConvertToLynxFunction(ctx, (JSObjectRef) value);
@@ -164,34 +166,35 @@ namespace jscore {
                 js_value = LynxValue::MakeObjectTemplate(
                         ConvertToLynxObjectTemplate(ctx, (JSObjectRef) value));
             } else {
-                js_value = ConvertToLynxObject(ctx, (JSObjectRef) value);
+                js_value = base::ScopedPtr<LynxValue>(
+                        ConvertToLynxObject(ctx, (JSObjectRef) value).Release());
             }
         }
         return js_value;
     }
 
-    LynxArray* JSCHelper::ConvertToLynxArray(JSContextRef ctx, JSObjectRef value) {
-        LynxArray* array = lynx_new LynxArray;
+    base::ScopedPtr<LynxArray> JSCHelper::ConvertToLynxArray(JSContextRef ctx, JSObjectRef value) {
+        base::ScopedPtr<LynxArray> array(lynx_new LynxArray());
         JSStringRef name = JSStringCreateWithUTF8CString("length");
         int length = JSValueToNumber(ctx, JSObjectGetProperty(ctx, value, name, NULL), NULL);
         JSStringRelease(name);
         for (int i = 0; i < length; ++i) {
             JSValueRef temp = JSObjectGetPropertyAtIndex(ctx, value, i, NULL);
-            array->Push(ConvertToLynxValue(ctx, temp));
+            array->Push(ConvertToLynxValue(ctx, temp).Release());
         }
         return array;
     }
 
-    LynxArray* JSCHelper::ConvertToLynxArray(JSContextRef ctx, JSValueRef *value, int length) {
-        LynxArray* array = lynx_new LynxArray();
+    base::ScopedPtr<LynxArray> JSCHelper::ConvertToLynxArray(JSContextRef ctx, JSValueRef *value, int length) {
+        base::ScopedPtr<LynxArray> array (lynx_new LynxArray());
         for (int i = 0; i < length; ++i) {
-            array->Push(ConvertToLynxValue(ctx, value[i]));
+            array->Push(ConvertToLynxValue(ctx, value[i]).Release());
         }
         return array;
     }
 
-    LynxObject* JSCHelper::ConvertToLynxObject(JSContextRef ctx, JSObjectRef value) {
-        LynxObject* lynx_object = lynx_new LynxObject();
+    base::ScopedPtr<LynxObject> JSCHelper::ConvertToLynxObject(JSContextRef ctx, JSObjectRef value) {
+        base::ScopedPtr<LynxObject> lynx_object(lynx_new LynxObject());
         JSObjectRef obj = JSValueToObject(ctx, value, NULL);
         JSPropertyNameArrayRef names = JSObjectCopyPropertyNames(ctx, obj);
         size_t len = JSPropertyNameArrayGetCount(names);
@@ -199,7 +202,7 @@ namespace jscore {
             JSStringRef key = JSPropertyNameArrayGetNameAtIndex(names, i);
             std::string key_str = JSCHelper::ConvertToString(ctx, key);
             JSValueRef value = JSObjectGetProperty(ctx, obj, key, NULL);
-            LynxValue* lynx_value = ConvertToLynxValue(ctx, value);
+            LynxValue* lynx_value = ConvertToLynxValue(ctx, value).Release();
             lynx_object->Set(key_str, lynx_value);
         }
         JSPropertyNameArrayRelease(names);
@@ -210,18 +213,17 @@ namespace jscore {
         return ObjectWrap::Unwrap<ObjectTemplate>(value)->target();
     }
 
-    LynxValue* JSCHelper::ConvertToLynxFunction(JSContextRef ctx, JSObjectRef value) {
+    base::ScopedPtr<LynxValue> JSCHelper::ConvertToLynxFunction(JSContextRef ctx, JSObjectRef value) {
         JSCContext* context = static_cast<JSCContext*>(JSObjectGetPrivate(JSContextGetGlobalObject(ctx)));
         JSCFunction* function = lynx_new JSCFunction(context, value);
-        LynxValue *result = LynxValue::MakeLynxFunction(function);
-        return result;
+        return LynxValue::MakeLynxFunction(function);
     }
 
     JSValueRef JSCHelper::ConvertToJSValue(JSContextRef ctx, jscore::LynxValue* value) {
-        JSValueRef js_obj = NULL;
         if (value == 0) {
             return JSValueMakeNull(ctx);
         }
+        JSValueRef js_obj = NULL;
         switch (value->type_) {
             case LynxValue::Type::VALUE_INT:
                 js_obj = ConvertToJSInt(ctx, value);

--- a/lynx/runtime/jsc/jsc_helper.h
+++ b/lynx/runtime/jsc/jsc_helper.h
@@ -26,12 +26,12 @@ namespace jscore {
         static std::string ConvertToString(JSContextRef ctx, JSValueRef value);
         static std::string ConvertToString(JSContextRef ctx, JSStringRef value);
         static std::string ConvertToString(LynxValue* value);
-        static LynxValue* ConvertToLynxValue(JSContextRef ctx, JSValueRef value);
-        static LynxArray* ConvertToLynxArray(JSContextRef ctx, JSObjectRef value);
-        static LynxArray* ConvertToLynxArray(JSContextRef ctx, JSValueRef *value, int length);
-        static LynxObject* ConvertToLynxObject(JSContextRef ctx, JSObjectRef value);
+        static base::ScopedPtr<LynxValue> ConvertToLynxValue(JSContextRef ctx, JSValueRef value);
+        static base::ScopedPtr<LynxArray> ConvertToLynxArray(JSContextRef ctx, JSObjectRef value);
+        static base::ScopedPtr<LynxArray> ConvertToLynxArray(JSContextRef ctx, JSValueRef *value, int length);
+        static base::ScopedPtr<LynxObject> ConvertToLynxObject(JSContextRef ctx, JSObjectRef value);
         static LynxObjectTemplate* ConvertToLynxObjectTemplate(JSContextRef ctx, JSObjectRef value);
-        static LynxValue* ConvertToLynxFunction(JSContextRef ctx, JSObjectRef value);
+        static base::ScopedPtr<LynxValue> ConvertToLynxFunction(JSContextRef ctx, JSObjectRef value);
 
         static JSValueRef ConvertToJSString(JSContextRef ctx, const std::string &s);
         static JSValueRef ConvertToJSString(JSContextRef ctx, const char* s);

--- a/lynx/runtime/jsc/objects/object_template.cpp
+++ b/lynx/runtime/jsc/objects/object_template.cpp
@@ -17,7 +17,7 @@ namespace jscore {
     void ObjectTemplate::BindingClass(ClassWrap* class_wrap, LynxObjectTemplate* object) {
         if (object != 0) {
 
-            auto field_map = object->fields();
+            auto& field_map = object->fields();
             for (auto& it : field_map) {
                 LynxObjectTemplate::Field field = it.second;
                 JSObjectGetPropertyCallback get = ObjectTemplate::GetPropertyCallback;
@@ -30,13 +30,13 @@ namespace jscore {
                                              NULL);
             }
 
-            auto method_map = object->methods();
+            auto& method_map = object->methods();
             for (auto& it : method_map) {
                 class_wrap->SetJSStaticFunction(it.first.c_str(),
                                                 ObjectTemplate::MethodCallback, NULL);
             }
 
-            const std::unordered_map<std::string, JSObjectCallAsFunctionCallback>& raw_method_map
+            auto& raw_method_map
                     = object->raw_methods();
             for (auto& it : raw_method_map) {
                 class_wrap->SetJSStaticFunction(it.first.c_str(),

--- a/lynx/runtime/jsc/objects/object_template.cpp
+++ b/lynx/runtime/jsc/objects/object_template.cpp
@@ -3,7 +3,6 @@
 #include "runtime/jsc/objects/object_template.h"
 #include "runtime/jsc/jsc_helper.h"
 #include "runtime/jsc/class_wrap.h"
-#include "runtime/jsc/jsc_context.h"
 
 namespace jscore {
     ObjectTemplate::ObjectTemplate(JSCContext* context, LynxObjectTemplate* obj)
@@ -18,8 +17,7 @@ namespace jscore {
     void ObjectTemplate::BindingClass(ClassWrap* class_wrap, LynxObjectTemplate* object) {
         if (object != 0) {
 
-            const std::unordered_map<std::string, LynxObjectTemplate::Field>& field_map
-                    = object->fields();
+            auto field_map = object->fields();
             for (auto& it : field_map) {
                 LynxObjectTemplate::Field field = it.second;
                 JSObjectGetPropertyCallback get = ObjectTemplate::GetPropertyCallback;
@@ -32,8 +30,7 @@ namespace jscore {
                                              NULL);
             }
 
-            const std::unordered_map<std::string, LynxObjectTemplate::LynxMethodCallback>& method_map
-                    = object->methods();
+            auto method_map = object->methods();
             for (auto& it : method_map) {
                 class_wrap->SetJSStaticFunction(it.first.c_str(),
                                                 ObjectTemplate::MethodCallback, NULL);

--- a/lynx/runtime/loader.cpp
+++ b/lynx/runtime/loader.cpp
@@ -33,13 +33,13 @@ namespace jscore {
 
     base::ScopedPtr<LynxValue>
     Loader::TraceCallback(LynxObjectTemplate* object,
-                             base::ScopedPtr<LynxArray> array) {
+                             base::ScopedPtr<LynxArray>& array) {
         return LynxValue::MakeValueScoped(NULL);
     }
 
     base::ScopedPtr<LynxValue>
     Loader::ScriptCallback(LynxObjectTemplate* object,
-                             base::ScopedPtr<LynxArray> array) {
+                             base::ScopedPtr<LynxArray>& array) {
         Loader* loader = static_cast<Loader*>(object);
         if (array.Get() != NULL && array->Size() > 0
                 && array->Get(0)->type_ == LynxValue::Type::VALUE_STRING) {

--- a/lynx/runtime/loader.h
+++ b/lynx/runtime/loader.h
@@ -49,10 +49,10 @@ namespace jscore {
     private:
 
         static base::ScopedPtr<LynxValue>
-        TraceCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray> array);
+        TraceCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray>& array);
 
         static base::ScopedPtr<LynxValue>
-        ScriptCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray> array);
+        ScriptCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray>& array);
 
         JSContext* context_;
     };

--- a/lynx/runtime/location.cpp
+++ b/lynx/runtime/location.cpp
@@ -96,56 +96,47 @@ namespace jscore {
 
     base::ScopedPtr<LynxValue> Location::GetHashCallback(LynxObjectTemplate* object) {
         Location* location = static_cast<Location*>(object);
-        LynxValue *value = LynxValue::MakeString(location->hash());
-        return base::ScopedPtr<LynxValue>(value);
+        return LynxValue::MakeString(location->hash());
     }
 
     base::ScopedPtr<LynxValue> Location::GetHostCallback(LynxObjectTemplate* object) {
         Location* location = static_cast<Location*>(object);
-        LynxValue *value = LynxValue::MakeString(location->host());
-        return base::ScopedPtr<LynxValue>(value);
+        return LynxValue::MakeString(location->host());
     }
 
     base::ScopedPtr<LynxValue> Location::GetHostNameCallback(LynxObjectTemplate* object) {
         Location* location = static_cast<Location*>(object);
-        LynxValue *value = LynxValue::MakeString(location->hostname());
-        return base::ScopedPtr<LynxValue>(value);
+        return LynxValue::MakeString(location->hostname());
     }
 
     base::ScopedPtr<LynxValue> Location::GetHrefCallback(LynxObjectTemplate* object) {
         Location* location = static_cast<Location*>(object);
-        LynxValue *value = LynxValue::MakeString(location->href());
-        return base::ScopedPtr<LynxValue>(value);
+        return LynxValue::MakeString(location->href());
     }
 
     base::ScopedPtr<LynxValue> Location::GetPathNameCallback(LynxObjectTemplate* object) {
         Location* location = static_cast<Location*>(object);
-        LynxValue *value = LynxValue::MakeString(location->pathname());
-        return base::ScopedPtr<LynxValue>(value);
+        return LynxValue::MakeString(location->pathname());
     }
 
     base::ScopedPtr<LynxValue> Location::GetPortCallback(LynxObjectTemplate* object) {
         Location* location = static_cast<Location*>(object);
-        LynxValue *value = LynxValue::MakeString(location->port());
-        return base::ScopedPtr<LynxValue>(value);
+        return LynxValue::MakeString(location->port());
     }
 
     base::ScopedPtr<LynxValue> Location::GetProtocolCallback(LynxObjectTemplate* object) {
         Location* location = static_cast<Location*>(object);
-        LynxValue *value = LynxValue::MakeString(location->protocol());
-        return base::ScopedPtr<LynxValue>(value);
+        return LynxValue::MakeString(location->protocol());
     }
 
     base::ScopedPtr<LynxValue> Location::GetSearchCallback(LynxObjectTemplate* object) {
         Location* location = static_cast<Location*>(object);
-        LynxValue *value = LynxValue::MakeString(location->search());
-        return base::ScopedPtr<LynxValue>(value);
+        return LynxValue::MakeString(location->search());
     }
 
     base::ScopedPtr<LynxValue> Location::GetOriginCallback(LynxObjectTemplate* object) {
         Location* location = static_cast<Location*>(object);
-        LynxValue *value = LynxValue::MakeString(location->origin());
-        return base::ScopedPtr<LynxValue>(value);
+        return LynxValue::MakeString(location->origin());
     }
 
     void Location::SetHashCallback(LynxObjectTemplate* object,

--- a/lynx/runtime/location.cpp
+++ b/lynx/runtime/location.cpp
@@ -56,7 +56,7 @@ namespace jscore {
     }
 
     base::ScopedPtr<LynxValue>
-    Location::ReplaceCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray> array) {
+    Location::ReplaceCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray>& array) {
         Location* location = static_cast<Location*>(object);
         if (array.Get() != NULL && array->Size() > 0) {
             LynxValue* value = array->Get(0);
@@ -70,7 +70,7 @@ namespace jscore {
 
 
     base::ScopedPtr<LynxValue>
-    Location::ReloadCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray> array) {
+    Location::ReloadCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray>& array) {
         Location* location = static_cast<Location*>(object);
         if (array.Get() != NULL && array->Size() > 0) {
             LynxValue* value = array->Get(0);
@@ -82,7 +82,7 @@ namespace jscore {
     }
 
     base::ScopedPtr<LynxValue>
-    Location::AssignCallback(LynxObjectTemplate *object, base::ScopedPtr<LynxArray> array) {
+    Location::AssignCallback(LynxObjectTemplate *object, base::ScopedPtr<LynxArray>& array) {
         Location* location = static_cast<Location*>(object);
         if (array.Get() != NULL && array->Size() > 0) {
             LynxValue* value = array->Get(0);

--- a/lynx/runtime/location.h
+++ b/lynx/runtime/location.h
@@ -109,13 +109,13 @@ namespace jscore {
 
 
         static base::ScopedPtr<LynxValue>
-        ReplaceCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray> array);
+        ReplaceCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray>& array);
 
         static base::ScopedPtr<LynxValue>
-        ReloadCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray> array);
+        ReloadCallback(LynxObjectTemplate* object, base::ScopedPtr<LynxArray>& array);
 
         static base::ScopedPtr<LynxValue>
-        AssignCallback(LynxObjectTemplate *object, base::ScopedPtr<LynxArray> array);
+        AssignCallback(LynxObjectTemplate *object, base::ScopedPtr<LynxArray>& array);
 
         static base::ScopedPtr<LynxValue> GetHashCallback(LynxObjectTemplate* object);
         static base::ScopedPtr<LynxValue> GetHostCallback(LynxObjectTemplate* object);

--- a/lynx/runtime/navigator.cpp
+++ b/lynx/runtime/navigator.cpp
@@ -18,31 +18,26 @@ namespace jscore {
     
     base::ScopedPtr<LynxValue> Navigator::GetUserAgentCallback(LynxObjectTemplate* object) {
         Navigator *navigator = static_cast<Navigator*>(object);
-        LynxValue *value = LynxValue::MakeString(navigator->user_agent());
-        return base::ScopedPtr<LynxValue>(value);
+        return LynxValue::MakeString(navigator->user_agent());
     }
 
     base::ScopedPtr<LynxValue> Navigator::GetAppCodeNameCallback(LynxObjectTemplate* object) {
         Navigator *navigator = static_cast<Navigator*>(object);
-        LynxValue *value = LynxValue::MakeString(navigator->app_code_name());
-        return base::ScopedPtr<LynxValue>(value);
+        return LynxValue::MakeString(navigator->app_code_name());
     }
 
     base::ScopedPtr<LynxValue> Navigator::GetAppNameCallback(LynxObjectTemplate* object) {
         Navigator *navigator = static_cast<Navigator*>(object);
-        LynxValue *value = LynxValue::MakeString(navigator->app_name());
-        return base::ScopedPtr<LynxValue>(value);
+        return LynxValue::MakeString(navigator->app_name());
     }
 
     base::ScopedPtr<LynxValue> Navigator::GetPlatformCallback(LynxObjectTemplate* object) {
         Navigator *navigator = static_cast<Navigator*>(object);
-        LynxValue *value = LynxValue::MakeString(navigator->platform());
-        return base::ScopedPtr<LynxValue>(value);
+        return LynxValue::MakeString(navigator->platform());
     }
 
     base::ScopedPtr<LynxValue> Navigator::GetAppVersionCallback(LynxObjectTemplate* object) {
         Navigator *navigator = static_cast<Navigator*>(object);
-        LynxValue *value = LynxValue::MakeString(navigator->app_version());
-        return base::ScopedPtr<LynxValue>(value);
+        return LynxValue::MakeString(navigator->app_version());
     }
 }

--- a/lynx/runtime/screen.cpp
+++ b/lynx/runtime/screen.cpp
@@ -18,13 +18,11 @@ namespace jscore {
 
     base::ScopedPtr<LynxValue> Screen::GetWidthCallback(LynxObjectTemplate* object) {
         int width = config::GlobalConfigData::GetInstance()->screen_width();
-        LynxValue *value = LynxValue::MakeInt(width);
-        return LynxValue::MakeValueScoped(value);
+        return LynxValue::MakeInt(width);
     }
 
     base::ScopedPtr<LynxValue> Screen::GetHeightCallback(LynxObjectTemplate* object) {
         int height = config::GlobalConfigData::GetInstance()->screen_height();
-        LynxValue *value = LynxValue::MakeInt(height);
-        return LynxValue::MakeValueScoped(value);
+        return LynxValue::MakeInt(height);
     }
 }


### PR DESCRIPTION
Feat:
1. Add nanoseconds to TimingTracker.
2. [Android] Support z-index on LynxUIView.
3. [Android] Support Image padding.
4. [iOS] Using generic on LynxUI.
5. Support fixed and absolute auto layout in flex.

Fix:
1. Using ref to pass through method.
2. Some changed styles should affect view's bounds and should measure and layout it's children.
3. Wrap ScopedPtr for LynxValue.
4. [iOS] On iOS use ref to prevent char* from being delete.
5. [iOS] Label measure bug.